### PR TITLE
Fix compilation of painter_test demo

### DIFF
--- a/demos/painter_test/main.cpp
+++ b/demos/painter_test/main.cpp
@@ -33,7 +33,7 @@ protected:
       std::ofstream file(name.str().c_str());
       file << pr->log();
 
-      std::cout << "Program Log and contents written to " << name << "\n";
+      std::cout << "Program Log and contents written to " << name.str() << "\n";
     }
 
     std::cout << "Vertex shaders written to:\n";


### PR DESCRIPTION
A missing .str() causes a compilation error with GCC 6.1.1 under Arch Linux. This small patch fixes the error.
