### PR TITLE
demos: drop boost::noncopyable use

### DIFF
--- a/demos/atlas_tests/glyph_test/main.cpp
+++ b/demos/atlas_tests/glyph_test/main.cpp
@@ -11,6 +11,7 @@
 #include <fastuidraw/gl_backend/opengl_trait.hpp>
 #include <fastuidraw/gl_backend/gl_context_properties.hpp>
 #include <fastuidraw/gl_backend/gl_program.hpp>
+#include <fastuidraw/util/util.hpp>
 #include "sdl_demo.hpp"
 #include "ImageLoader.hpp"
 #include "PanZoomTracker.hpp"
@@ -92,7 +93,7 @@ private:
       geometry_backing_store_auto,
     };
 
-  class per_program:boost::noncopyable
+  class per_program:fastuidraw::noncopyable
   {
   public:
     void
@@ -105,7 +106,7 @@ private:
     GLint m_fg_color_loc;
   };
 
-  class per_draw:boost::noncopyable
+  class per_draw:fastuidraw::noncopyable
   {
   public:
     per_draw(void);

--- a/demos/common/PainterWidget.hpp
+++ b/demos/common/PainterWidget.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <list>
-#include <boost/utility.hpp>
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/matrix.hpp>
+#include <fastuidraw/util/util.hpp>
 #include <fastuidraw/painter/painter.hpp>
 
-class PainterWidget:boost::noncopyable
+class PainterWidget:fastuidraw::noncopyable
 {
 public:
 

--- a/demos/common/generic_command_line.hpp
+++ b/demos/common/generic_command_line.hpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <string>
 #include <sstream>
-#include <boost/utility.hpp>
+#include <fastuidraw/util/util.hpp>
 
 class command_line_register;
 class command_line_argument;
@@ -52,7 +52,7 @@ class command_line_argument;
   children's check_arg() method to get the values
   from a command line argument list.
  */
-class command_line_register:boost::noncopyable
+class command_line_register:fastuidraw::noncopyable
 {
 private:
   friend class command_line_argument;
@@ -88,7 +88,7 @@ public:
   A command_line_argument reads from an argument
   list to set a value.
  */
-class command_line_argument:boost::noncopyable
+class command_line_argument:fastuidraw::noncopyable
 {
 private:
 

--- a/demos/painter_cells/cell.hpp
+++ b/demos/painter_cells/cell.hpp
@@ -4,6 +4,7 @@
 #include <fastuidraw/text/glyph_cache.hpp>
 #include <fastuidraw/text/font.hpp>
 #include <fastuidraw/painter/painter.hpp>
+#include <fastuidraw/util/util.hpp>
 
 #include "ostream_utility.hpp"
 #include "PainterWidget.hpp"
@@ -11,7 +12,7 @@
 
 using namespace fastuidraw;
 
-class CellSharedState:boost::noncopyable
+class CellSharedState:noncopyable
 {
 public:
   CellSharedState(void):


### PR DESCRIPTION
We already offer `fastuidraw::noncopyable`.