### PR TITLE
fastuidraw: use std::atomic instead of boost::atomic

### DIFF
--- a/src/fastuidraw/painter/packing/painter_packer.cpp
+++ b/src/fastuidraw/painter/packing/painter_packer.cpp
@@ -17,7 +17,7 @@
  */
 
 
-
+#include <atomic>
 #include <vector>
 #include <list>
 #include <cstring>
@@ -106,10 +106,10 @@ namespace
          thread safe by using atomic operation on m_free_slots_back.
          The following code would make it thread safe.
 
-         return_value = m_free_slots_back.fetch_sub(1, boost::memory_order_aquire)
+         return_value = m_free_slots_back.fetch_sub(1, std::memory_order_aquire)
          if(return_value < 0)
            {
-              m_free_slots_back.fetch_add(1, boost::memory_order_aquire);
+              m_free_slots_back.fetch_add(1, std::memory_order_aquire);
            }
          return return_value;
        */
@@ -131,8 +131,8 @@ namespace
          The following code would make it thread safe.
 
          int S;
-         S = m_free_slots_back.fetch_add(1, boost::memory_order_release);
-         boost::atomic_thread_fence(boost::memory_order_acquire);
+         S = m_free_slots_back.fetch_add(1, std::memory_order_release);
+         std::atomic_thread_fence(std::memory_order_acquire);
          assert(S < pool_size);
          m_free_slots[S] = v;
        */

--- a/src/fastuidraw/util/reference_count_atomic.cpp
+++ b/src/fastuidraw/util/reference_count_atomic.cpp
@@ -16,22 +16,12 @@
  *
  */
 
-#include <boost/version.hpp>
-
-#if (BOOST_VERSION < 105300)
-  #define FASTUIDRAW_USE_DETAIL_ATOMIC
-#endif
-
-#ifndef FASTUIDRAW_USE_DETAIL_ATOMIC
-  #include <boost/atomic.hpp>
-  typedef boost::atomic<int> atomic_int;
-#else
-  #include <boost/detail/atomic_count.hpp>
-  typedef boost::detail::atomic_count atomic_int;
-#endif
+#include <atomic>
 
 #include <fastuidraw/util/fastuidraw_memory.hpp>
 #include <fastuidraw/util/reference_count_atomic.hpp>
+
+typedef std::atomic<int> atomic_int;
 
 namespace
 {
@@ -71,15 +61,9 @@ add_reference(void)
   ReferenceCountAtomicPrivate *d;
 
   d = static_cast<ReferenceCountAtomicPrivate*>(m_d);
-  #ifndef FASTUIDRAW_USE_DETAIL_ATOMIC
     {
-      d->m_reference_count.fetch_add(1, boost::memory_order_relaxed);
+      d->m_reference_count.fetch_add(1, std::memory_order_relaxed);
     }
-  #else
-    {
-      ++(d->m_reference_count);
-    }
-  #endif
 }
 
 
@@ -91,11 +75,10 @@ remove_reference(void)
   bool return_value;
 
   d = static_cast<ReferenceCountAtomicPrivate*>(m_d);
-  #ifndef FASTUIDRAW_USE_DETAIL_ATOMIC
     {
-      if (d->m_reference_count.fetch_sub(1, boost::memory_order_release) == 1)
+      if (d->m_reference_count.fetch_sub(1, std::memory_order_release) == 1)
         {
-          boost::atomic_thread_fence(boost::memory_order_acquire);
+          std::atomic_thread_fence(std::memory_order_acquire);
           return_value = true;
         }
       else
@@ -103,13 +86,6 @@ remove_reference(void)
           return_value = false;
         }
     }
-  #else
-    {
-      long v;
-      v = --(d->m_reference_count);
-      return_value = (v == 0);
-    }
-  #endif
 
   return return_value;
 }


### PR DESCRIPTION
Simple replacement with `std::atomic`.
Changes are done in cpp files. Thus C++11 feature is not exposed to users.