### PR TITLE
fastuidraw/freetype: replace boost::bind with std::bind

### DIFF
--- a/src/fastuidraw/text/private/freetype_curvepair_util.cpp
+++ b/src/fastuidraw/text/private/freetype_curvepair_util.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <map>
+#include <functional>
 
 #include <fastuidraw/text/glyph_render_data_curve_pair.hpp>
 #include "freetype_util.hpp"
@@ -347,9 +348,9 @@ consumer_state(CollapsingContourEmitter *master,
   m_master(master),
   m_data(data)
 {
-  signal_emit_curve::slot_type C(boost::bind(&CollapsingContourEmitter::consumer_state::consume_curve,
-                                             this, _1));
-  signal_end_contour::slot_type O(boost::bind(&CollapsingContourEmitter::consumer_state::consume_contour,
+  signal_emit_curve::slot_type C(std::bind(&CollapsingContourEmitter::consumer_state::consume_curve,
+                                             this, std::placeholders::_1));
+  signal_end_contour::slot_type O(std::bind(&CollapsingContourEmitter::consumer_state::consume_contour,
                                               this));
 
   m_consume_curves=m_master->m_real_worker.connect_emit_curve(C);

--- a/src/fastuidraw/text/private/freetype_util.cpp
+++ b/src/fastuidraw/text/private/freetype_util.cpp
@@ -129,8 +129,9 @@ Other important tricks:
 
  **********************************************/
 
-#include "freetype_util.hpp"
+#include <functional>
 
+#include "freetype_util.hpp"
 
 namespace
 {
@@ -1849,10 +1850,10 @@ namespace detail
     boost::signals2::connection c0, c1;
 
     assert(emitter!=NULL);
-    c0=emitter->connect_emit_curve( boost::bind(&RawOutlineData::catch_curve,
-                                                this, _1));
+    c0=emitter->connect_emit_curve( std::bind(&RawOutlineData::catch_curve,
+                                                this, std::placeholders::_1));
 
-    c1=emitter->connect_emit_end_contour( boost::bind(&RawOutlineData::mark_contour_end,
+    c1=emitter->connect_emit_end_contour( std::bind(&RawOutlineData::mark_contour_end,
                                                       this));
 
     emitter->produce_contours(m_dbg);

--- a/src/fastuidraw/text/private/freetype_util.hpp
+++ b/src/fastuidraw/text/private/freetype_util.hpp
@@ -34,7 +34,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <boost/signals2.hpp>
-#include <boost/bind.hpp>
 #include <boost/multi_array.hpp>
 #include <boost/tuple/tuple.hpp>
 


### PR DESCRIPTION
Simple replacement with `std::bind`.