### PR TITLE
fastuidraw: replace boost::multi_array with array2d and array3d

### DIFF
--- a/src/fastuidraw/private/array2d.hpp
+++ b/src/fastuidraw/private/array2d.hpp
@@ -1,0 +1,120 @@
+/*!
+ * \file array2d.hpp
+ * \brief file array2d.hpp
+ *
+ * Copyright 2017 by Yusuke Suzuki.
+ *
+ * Contact: utatane.tea@gmail.com
+ *
+ * This Source Code Form is subject to the
+ * terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with
+ * this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ *
+ * \author Yusuke Suzuki <utatane.tea@gmail.com>
+ *
+ */
+
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace fastuidraw {
+
+/*!\addtogroup Utility
+  @{
+ */
+
+/*!
+  A generic array2d class:
+
+ If FASTUIDRAW_VECTOR_BOUND_CHECK is defined,
+ will perform bounds checking.
+ \tparam T array2d entry type
+*/
+template<typename T>
+class array2d
+{
+private:
+  std::vector<T> m_data;
+#ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+  size_t m_M;
+#endif
+  size_t m_N;
+
+public:
+
+  /*!
+    Ctor.
+    Initializes an MxN array2d.
+  */
+  array2d(size_t M, size_t N)
+    : m_data(M * N, T())
+#ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+    , m_M(M)
+#endif
+    , m_N(N)
+  {
+  }
+
+  /*!
+    Resizes the array3d.
+   */
+  void
+  resize(size_t M, size_t N)
+  {
+#ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+    m_M = M;
+#endif
+    m_N = N;
+    m_data.resize(M * N, T());
+  }
+
+  /*!
+    Fills values with the parameter value.
+    \param value value to fill values with
+   */
+  void
+  fill(const T& value)
+  {
+    std::fill(m_data.begin(), m_data.end(), value);
+
+  }
+
+  /*!
+    Returns the value in the vector corresponding M[i,j]
+    \param row row(vertical coordinate) in the array2d
+    \param col column(horizontal coordinate) in the array2d
+   */
+  T&
+  operator()(unsigned int row, unsigned int col)
+  {
+    #ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+      assert(row<m_M);
+      assert(col<m_N);
+    #endif
+    return m_data[m_N*row+col];
+  }
+
+  /*!
+    Returns the value in the vector corresponding M[i,j]
+    \param row row(vertical coordinate) in the array2d
+    \param col column(horizontal coordinate) in the array2d
+   */
+  const T&
+  operator()(unsigned int row, unsigned int col) const
+  {
+    #ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+      assert(row<m_M);
+      assert(col<m_N);
+    #endif
+    return m_data[m_N*row+col];
+  }
+};
+
+} //namespace
+
+/*! @} */

--- a/src/fastuidraw/private/array3d.hpp
+++ b/src/fastuidraw/private/array3d.hpp
@@ -1,0 +1,126 @@
+/*!
+ * \file array3d.hpp
+ * \brief file array3d.hpp
+ *
+ * Copyright 2017 by Yusuke Suzuki.
+ *
+ * Contact: utatane.tea@gmail.com
+ *
+ * This Source Code Form is subject to the
+ * terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with
+ * this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ *
+ * \author Yusuke Suzuki <utatane.tea@gmail.com>
+ *
+ */
+
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace fastuidraw {
+
+/*!\addtogroup Utility
+  @{
+ */
+
+/*!
+  A generic array3d class:
+
+ If FASTUIDRAW_VECTOR_BOUND_CHECK is defined,
+ will perform bounds checking.
+ \tparam T array3d entry type
+*/
+template<typename T>
+class array3d
+{
+private:
+  std::vector<T> m_data;
+#ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+  size_t m_A;
+#endif
+  size_t m_B;
+  size_t m_C;
+
+public:
+
+  /*!
+    Ctor.
+    Initializes an AxBxC array3d.
+  */
+  array3d(size_t A, size_t B, size_t C)
+    : m_data(A * B * C, T())
+#ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+    , m_A(A)
+#endif
+    , m_B(B)
+    , m_C(C)
+  {
+  }
+
+  /*!
+    Resizes the array3d.
+   */
+  void
+  resize(size_t A, size_t B, size_t C)
+  {
+#ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+    m_A = A;
+#endif
+    m_B = B;
+    m_C = C;
+    m_data.resize(A * B * C, T());
+  }
+
+  /*!
+    Fills values with the parameter value.
+    \param value value to fill values with
+   */
+  void
+  fill(const T& value)
+  {
+    std::fill(m_data.begin(), m_data.end(), value);
+  }
+
+  /*!
+    Returns the value in the vector corresponding M[i,j,k]
+    \param a first index in the array3d
+    \param b second index in the array3d
+    \param c third index in the array3d
+   */
+  T&
+  operator()(unsigned int a, unsigned int b, unsigned int c)
+  {
+    #ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+      assert(a<m_A);
+      assert(b<m_B);
+      assert(c<m_C);
+    #endif
+    return m_data[(m_B * m_C)*a+m_C*b+c];
+  }
+
+  /*!
+    Returns the value in the vector corresponding M[i,j,k]
+    \param a first index in the array3d
+    \param b second index in the array3d
+    \param c third index in the array3d
+   */
+  const T&
+  operator()(unsigned int a, unsigned int b, unsigned int c) const
+  {
+    #ifdef FASTUIDRAW_VECTOR_BOUND_CHECK
+      assert(a<m_A);
+      assert(b<m_B);
+      assert(c<m_C);
+    #endif
+    return m_data[(m_B * m_C)*a+m_C*b+c];
+  }
+};
+
+} //namespace
+
+/*! @} */

--- a/src/fastuidraw/text/freetype_font.cpp
+++ b/src/fastuidraw/text/freetype_font.cpp
@@ -25,6 +25,7 @@
 
 #include "private/freetype_util.hpp"
 #include "private/freetype_curvepair_util.hpp"
+#include "../private/array2d.hpp"
 #include "../private/util_private.hpp"
 
 #include <ft2build.h>
@@ -424,7 +425,7 @@ compute_rendering_data(uint32_t glyph_code,
        */
       output.resize(bitmap_sz + fastuidraw::ivec2(1, 1));
       std::fill(output.distance_values().begin(), output.distance_values().end(), 0);
-      boost::multi_array<fastuidraw::detail::distance_return_type, 2> distance_values(boost::extents[bitmap_sz.x()][bitmap_sz.y()]);
+      fastuidraw::array2d<fastuidraw::detail::distance_return_type> distance_values(bitmap_sz.x(), bitmap_sz.y());
 
       outline_data.compute_distance_values(distance_values, max_distance, true);
       for(int y = 0; y < bitmap_sz.y(); ++y)
@@ -436,9 +437,9 @@ compute_rendering_data(uint32_t glyph_code,
               float v0;
 
               location = x + y * output.resolution().x();
-              outside = (distance_values[x][y].m_solution_count.winding_number() == 0);
+              outside = (distance_values(x, y).m_solution_count.winding_number() == 0);
 
-              v0 = distance_values[x][y].m_distance.value();
+              v0 = distance_values(x, y).m_distance.value();
               v0 = std::min(v0 / max_distance, 1.0f);
 
               output.distance_values()[location] = pixel_value_from_distance(v0, outside);

--- a/src/fastuidraw/text/private/freetype_curvepair_util.cpp
+++ b/src/fastuidraw/text/private/freetype_curvepair_util.cpp
@@ -24,6 +24,7 @@
 #include <fastuidraw/text/glyph_render_data_curve_pair.hpp>
 #include "freetype_util.hpp"
 #include "freetype_curvepair_util.hpp"
+#include "../../private/array2d.hpp"
 
 
 /*
@@ -205,8 +206,8 @@ namespace
     const TaggedOutlineData &m_outline_data;
     c_array<uint16_t> m_index_pixels;
     std::vector<bool> m_reverse_components;
-    boost::multi_array<fastuidraw::detail::analytic_return_type, 2> m_intersection_data;
-    boost::multi_array<int, 2> m_winding_values;
+    array2d<fastuidraw::detail::analytic_return_type> m_intersection_data;
+    array2d<int> m_winding_values;
   };
 
 
@@ -643,8 +644,8 @@ IndexTextureData(TaggedOutlineData &outline_data,
   m_bitmap_sz(bitmap_size),
   m_outline_data(outline_data),
   m_index_pixels(pixel_data_out),
-  m_intersection_data(boost::extents[m_bitmap_sz.x()][m_bitmap_sz.y()]),
-  m_winding_values(boost::extents[m_bitmap_sz.x()][m_bitmap_sz.y()])
+  m_intersection_data(m_bitmap_sz.x(), m_bitmap_sz.y()),
+  m_winding_values(m_bitmap_sz.x(), m_bitmap_sz.y())
 {
   std::fill(m_index_pixels.begin(), m_index_pixels.end(), fastuidraw::GlyphRenderDataCurvePair::completely_empty_texel);
   assert(m_index_pixels.size() == static_cast<unsigned int>(m_bitmap_sz.x() * m_bitmap_sz.y()));
@@ -668,7 +669,7 @@ IndexTextureData(TaggedOutlineData &outline_data,
     {
       for(int y=0;y<m_bitmap_sz.y() - 1; ++y)
         {
-          fastuidraw::detail::analytic_return_type &current(m_intersection_data[x][y]);
+          fastuidraw::detail::analytic_return_type &current(m_intersection_data(x, y));
           for(int side=0; side<4; ++side)
             {
               for(std::vector<fastuidraw::detail::simple_line>::iterator
@@ -1152,8 +1153,8 @@ select_index(int x, int y)
   uint16_t pixel(0);
   curve_cache curves;
   fastuidraw::ivec2 texel_bl, texel_tr;
-  fastuidraw::detail::analytic_return_type &current(m_intersection_data[x][y]);
-  int winding_value(m_winding_values[x][y]);
+  fastuidraw::detail::analytic_return_type &current(m_intersection_data(x, y));
+  int winding_value(m_winding_values(x, y));
 
   texel_bl=m_outline_data.point_from_bitmap(fastuidraw::ivec2(x,y),
                                             fastuidraw::detail::bitmap_begin);

--- a/src/fastuidraw/text/private/freetype_util.cpp
+++ b/src/fastuidraw/text/private/freetype_util.cpp
@@ -663,7 +663,7 @@ namespace
 
   void
   grab_simple_lines(grab_map &hits_found,
-                    const boost::multi_array<analytic_return_type, 2> &dataLOD0,
+                    const array2d<analytic_return_type> &dataLOD0,
                     int fixed_value, range_type<int> range,
                     enum coordinate_type coord,
                     enum boundary_type which_to_grab)
@@ -676,7 +676,7 @@ namespace
         pix[varying_coordinate(coord)]<range.m_end;
         ++pix[varying_coordinate(coord)])
       {
-        const analytic_return_type &R(dataLOD0[pix.x()][pix.y()]);
+        const analytic_return_type &R(dataLOD0(pix.x(), pix.y()));
         for(int j=0, end_j=R.m_intersecions[which_to_grab].size(); j<end_j; ++j)
           {
             const simple_line &L(R.m_intersecions[which_to_grab][j]);
@@ -2103,7 +2103,7 @@ namespace detail
 
   void
   OutlineData::
-  compute_distance_values(boost::multi_array<distance_return_type, 2> &victim,
+  compute_distance_values(array2d<distance_return_type> &victim,
                           float max_dist_value, bool compute_winding_number) const
   {
     int radius;
@@ -2118,7 +2118,7 @@ namespace detail
 
   void
   OutlineData::
-  init_distance_values(boost::multi_array<distance_return_type, 2> &victim,
+  init_distance_values(array2d<distance_return_type> &victim,
                        float max_dist_value) const
   {
     //init victim:
@@ -2126,14 +2126,14 @@ namespace detail
       {
         for(int y=0;y<bitmap_size().y();++y)
           {
-            victim[x][y].m_distance.init(max_dist_value);
+            victim(x, y).m_distance.init(max_dist_value);
           }
       }
   }
 
   void
   OutlineData::
-  compute_outline_point_values(boost::multi_array<distance_return_type, 2> &victim,
+  compute_outline_point_values(array2d<distance_return_type> &victim,
                                int radius) const
   {
     for(unsigned int i=0, end_i=number_curves(); i<end_i; ++i)
@@ -2166,7 +2166,7 @@ namespace detail
                 dc=candidate.L1norm();
                 dc*=distance_scale_factor();
 
-                victim[x][y].m_distance.update_value(dc);
+                victim(x, y).m_distance.update_value(dc);
               }
           }
 
@@ -2175,7 +2175,7 @@ namespace detail
 
   void
   OutlineData::
-  compute_zero_derivative_values(boost::multi_array<distance_return_type, 2> &victim,
+  compute_zero_derivative_values(array2d<distance_return_type> &victim,
                                  int radius) const
   {
     for(unsigned int i=0, end_i=number_curves(); i<end_i; ++i)
@@ -2210,7 +2210,7 @@ namespace detail
                     dc=candidate.L1norm();
                     dc*=distance_scale_factor();
 
-                    victim[x][y].m_distance.update_value(dc);
+                    victim(x, y).m_distance.update_value(dc);
 
                   }
               }
@@ -2221,7 +2221,7 @@ namespace detail
 
   void
   OutlineData::
-  compute_fixed_line_values(boost::multi_array<distance_return_type, 2> &victim,
+  compute_fixed_line_values(array2d<distance_return_type> &victim,
                             bool compute_winding_number) const
   {
     std::vector< std::vector<solution_point> > work_room;
@@ -2234,7 +2234,7 @@ namespace detail
   void
   OutlineData::
   compute_fixed_line_values(enum coordinate_type coord_tp,
-                            boost::multi_array<distance_return_type, 2> &victim,
+                            array2d<distance_return_type> &victim,
                             std::vector< std::vector<solution_point> > &work_room,
                             bool compute_winding_number) const
   {
@@ -2330,15 +2330,15 @@ namespace detail
 
                 dc= std::abs(p-L[cindex].m_value);
                 dc*=distance_scale_factor();
-                victim[pixel.x()][pixel.y()].m_distance.update_value(dc);
+                victim(pixel.x(), pixel.y()).m_distance.update_value(dc);
 
               }
 
 
-            victim[pixel.x()][pixel.y()].
+            victim(pixel.x(), pixel.y()).
               m_solution_count.increment(sol[coord][0], current_count);
 
-            victim[pixel.x()][pixel.y()].
+            victim(pixel.x(), pixel.y()).
               m_solution_count.increment(sol[coord][1], total_count - current_count);
           }
 
@@ -2368,7 +2368,7 @@ namespace detail
                 //that are falling
                 sum+=cts[x];
 
-                victim[pix.x()][pix.y()].
+                victim(pix.x(), pix.y()).
                   m_solution_count.increment_winding(sum);
               }
 
@@ -2462,12 +2462,10 @@ namespace detail
 
   void
   OutlineData::
-  compute_winding_numbers(boost::multi_array<int, 2> &victim,
+  compute_winding_numbers(array2d<int> &victim,
                           ivec2 offset_from_center) const
   {
-    std::fill(victim.data(),
-              victim.data()+victim.num_elements(), 0);
-
+    victim.fill(0);
     for(int y=0;y<bitmap_size().y(); ++y)
       {
         std::vector<solution_point> solves;
@@ -2493,7 +2491,7 @@ namespace detail
             //center that are rising minus the number of curves before the texel
             //that are falling
             sum+=cts[x];
-            victim[x][y]+=sum;
+            victim(x, y)+=sum;
           }
       }
   }
@@ -2501,7 +2499,7 @@ namespace detail
 
   void
   OutlineData::
-  compute_analytic_values(boost::multi_array<analytic_return_type, 2> &victim,
+  compute_analytic_values(array2d<analytic_return_type> &victim,
                           std::vector<bool> &component_reversed,
                           bool include_pt_intersections) const
   {
@@ -2554,7 +2552,7 @@ namespace detail
   void
   OutlineData::
   compute_analytic_curve_values_fixed(enum coordinate_type coord,
-                                      boost::multi_array<analytic_return_type, 2> &victim,
+                                      array2d<analytic_return_type> &victim,
                                       std::vector<int> &reverse_curve_count,
                                       bool include_pt_intersections) const
   {
@@ -2644,7 +2642,7 @@ namespace detail
             //prev_index gives the number of curves below texel_bottom:
             if(x>0)
               {
-                victim[prev_pixel.x()][prev_pixel.y()].m_parity_count[prev_bound]=prev_index;
+                victim(prev_pixel.x(), prev_pixel.y()).m_parity_count[prev_bound]=prev_index;
 
                 bool filled;
                 filled= ( (prev_index&1)!=0);
@@ -2693,7 +2691,7 @@ namespace detail
 
             if(x<bitmap_size()[coord])
               {
-                victim[pixel.x()][pixel.y()].m_parity_count[bound]=prev_index;
+                victim(pixel.x(), pixel.y()).m_parity_count[bound]=prev_index;
               }
 
             //at this point in time if prev_index and current index differ, then
@@ -2709,14 +2707,14 @@ namespace detail
                   {
                     if(x>0)
                       {
-                        victim[prev_pixel.x()][prev_pixel.y()].m_intersecions[prev_bound].push_back(L[k]);
-                        victim[prev_pixel.x()][prev_pixel.y()].m_empty=false;
+                        victim(prev_pixel.x(), prev_pixel.y()).m_intersecions[prev_bound].push_back(L[k]);
+                        victim(prev_pixel.x(), prev_pixel.y()).m_empty=false;
                       }
 
                     if(x<bitmap_size()[coord])
                       {
-                        victim[pixel.x()][pixel.y()].m_intersecions[bound].push_back(L[k]);
-                        victim[pixel.x()][pixel.y()].m_empty=false;
+                        victim(pixel.x(), pixel.y()).m_intersecions[bound].push_back(L[k]);
+                        victim(pixel.x(), pixel.y()).m_empty=false;
                       }
                   }
               }
@@ -2730,7 +2728,7 @@ namespace detail
   int
   OutlineData::
   compute_localized_affectors_LOD(int LOD,
-                                  const boost::multi_array<analytic_return_type, 2> &dataLOD0,
+                                  const array2d<analytic_return_type> &dataLOD0,
                                   const ivec2 &LOD_bitmap_location,
                                   c_array<curve_segment> out_curves) const
   {

--- a/src/fastuidraw/text/private/freetype_util.hpp
+++ b/src/fastuidraw/text/private/freetype_util.hpp
@@ -36,8 +36,6 @@
 #include <unistd.h>
 #include <mutex>
 #include <boost/signals2.hpp>
-#include <boost/multi_array.hpp>
-
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/c_array.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -45,6 +43,7 @@
 #include <fastuidraw/util/fastuidraw_memory.hpp>
 #include <fastuidraw/path.hpp>
 
+#include "../../private/array2d.hpp"
 #include "../../private/util_private.hpp"
 
 #include <ft2build.h>
@@ -2323,7 +2322,7 @@ namespace detail
                                     as well for each texel.
      */
     void
-    compute_distance_values(boost::multi_array<distance_return_type, 2> &victim,
+    compute_distance_values(array2d<distance_return_type> &victim,
                             float max_dist,
                             bool compute_winding_number) const;
 
@@ -2341,7 +2340,7 @@ namespace detail
                                 coordinates of the curves
      */
     void
-    compute_winding_numbers(boost::multi_array<int, 2> &victim,
+    compute_winding_numbers(array2d<int> &victim,
                             ivec2 offset_from_center=ivec2(0,0)) const;
 
     /*!\fn void compute_analytic_values
@@ -2362,7 +2361,7 @@ namespace detail
                                       the boudnary include that too.
      */
     void
-    compute_analytic_values(boost::multi_array<analytic_return_type, 2> &victim,
+    compute_analytic_values(array2d<analytic_return_type> &victim,
                             std::vector<bool> &component_reversed,
                             bool include_pt_intersections=false) const;
 
@@ -2469,7 +2468,7 @@ namespace detail
                                 const ivec2 &bitmap_location,
                                 c_array<curve_segment> out_curves) const;
 
-    /*!\fn int compute_localized_affectors(const boost::multi_array<analytic_return_type, 2> &,
+    /*!\fn int compute_localized_affectors(const array2d<analytic_return_type> &,
                                            const ivec2&, c_array<curve_segment>) const
       Computes the curves intersecting a named texel.
       Returns the number of curves found. Provdied as
@@ -2485,11 +2484,11 @@ namespace detail
       \param out_curves pre-allocated array to store the output in
      */
     int
-    compute_localized_affectors(const boost::multi_array<analytic_return_type, 2> &R,
+    compute_localized_affectors(const array2d<analytic_return_type> &R,
                                 const ivec2 &bitmap_location,
                                 c_array<curve_segment> out_curves) const
     {
-      return compute_localized_affectors( R[bitmap_location.x()][bitmap_location.y()],
+      return compute_localized_affectors( R(bitmap_location.x(), bitmap_location.y()),
                                           bitmap_location, out_curves);
     }
 
@@ -2503,7 +2502,7 @@ namespace detail
      */
     int
     compute_localized_affectors_LOD(int LOD,
-                                    const boost::multi_array<analytic_return_type, 2> &dataLOD0,
+                                    const array2d<analytic_return_type> &dataLOD0,
                                     const ivec2 &LOD_bitmap_location,
                                     c_array<curve_segment> out_curves) const;
 
@@ -2532,29 +2531,29 @@ namespace detail
                                   std::vector<int> &cts) const;
 
     void
-    compute_fixed_line_values(boost::multi_array<distance_return_type, 2> &victim,
+    compute_fixed_line_values(array2d<distance_return_type> &victim,
                               bool compute_winding_number) const;
 
     void
     compute_fixed_line_values(enum coordinate_type coord_tp,
-                              boost::multi_array<distance_return_type, 2> &victim,
+                              array2d<distance_return_type> &victim,
                               std::vector< std::vector<solution_point> > &work_room,
                               bool compute_winding_number) const;
 
     void
-    compute_outline_point_values(boost::multi_array<distance_return_type, 2> &victim,
+    compute_outline_point_values(array2d<distance_return_type> &victim,
                                  int radius) const;
 
     void
-    compute_zero_derivative_values(boost::multi_array<distance_return_type, 2> &victim,
+    compute_zero_derivative_values(array2d<distance_return_type> &victim,
                                    int radius) const;
 
     void
-    init_distance_values(boost::multi_array<distance_return_type, 2> &victim,
+    init_distance_values(array2d<distance_return_type> &victim,
                          float max_dist_value) const;
     void
     compute_analytic_curve_values_fixed(enum coordinate_type coord,
-                                        boost::multi_array<analytic_return_type, 2> &victim,
+                                        array2d<analytic_return_type> &victim,
                                         std::vector<int> &reverse_curve_count,
                                         bool include_pt_intersections) const;
 


### PR DESCRIPTION
Replace `boost::multi_array` with `array2d` and `array3d` implemented on the top of `std::vector`.