### PR TITLE
fastuidraw/text: implement simple Signal and drop boost::signals2

### DIFF
--- a/src/fastuidraw/text/private/freetype_util.cpp
+++ b/src/fastuidraw/text/private/freetype_util.cpp
@@ -1847,14 +1847,9 @@ namespace detail
   RawOutlineData::
   build_outline(ContourEmitterBase *emitter)
   {
-    boost::signals2::connection c0, c1;
-
     assert(emitter!=NULL);
-    c0=emitter->connect_emit_curve( std::bind(&RawOutlineData::catch_curve,
-                                                this, std::placeholders::_1));
-
-    c1=emitter->connect_emit_end_contour( std::bind(&RawOutlineData::mark_contour_end,
-                                                      this));
+    auto c0=emitter->connect_emit_curve(std::bind(&RawOutlineData::catch_curve, this, std::placeholders::_1));
+    auto c1=emitter->connect_emit_end_contour(std::bind(&RawOutlineData::mark_contour_end, this));
 
     emitter->produce_contours(m_dbg);
 

--- a/src/fastuidraw/text/private/freetype_util.hpp
+++ b/src/fastuidraw/text/private/freetype_util.hpp
@@ -35,7 +35,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <mutex>
-#include <boost/signals2.hpp>
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/c_array.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -44,6 +43,7 @@
 #include <fastuidraw/path.hpp>
 
 #include "../../private/array2d.hpp"
+#include "signal.hpp"
 #include "../../private/util_private.hpp"
 
 #include <ft2build.h>
@@ -1539,25 +1539,13 @@ namespace detail
       conveniance typedef for the signal type
       when a curve is emitted.
      */
-    typedef boost::signals2::signal<void (BezierCurve*),
-                                    boost::signals2::optional_last_value<void>,
-                                    int,
-                                    std::less<int>,
-                                    boost::function<void (BezierCurve*)>,
-                                    boost::function<void (const boost::signals2::connection&, BezierCurve*)>,
-                                    dummy_mutex> signal_emit_curve;
+    typedef Signal<std::function<void (BezierCurve*)>> signal_emit_curve;
 
     /*!\typedef signal_end_contour
       conveniance typedef for the signal type
       when a contour ends
      */
-    typedef boost::signals2::signal<void (),
-                                    boost::signals2::optional_last_value<void>,
-                                    int,
-                                    std::less<int>,
-                                    boost::function<void ()>,
-                                    boost::function<void (const boost::signals2::connection&)>,
-                                    dummy_mutex> signal_end_contour;
+    typedef Signal<std::function<void ()>> signal_end_contour;
 
     virtual
     ~ContourEmitterBase(void)
@@ -1597,24 +1585,24 @@ namespace detail
       m_o();
     }
 
-    /*!\fn boost::signals2::connection connect_emit_curve
+    /*!\fn signal_emit_curve::Connection connect_emit_curve
       Connect to the emit curve signal
       \param c slot to call on emit curve signal
      */
-    boost::signals2::connection
-    connect_emit_curve(signal_emit_curve::slot_type c)
+    signal_emit_curve::Connection
+    connect_emit_curve(signal_emit_curve::SlotType&& c)
     {
-      return m_c.connect(c);
+      return m_c.connect(std::move(c));
     }
 
-    /*!\fn boost::signals2::connection connect_emit_end_contour
+    /*!\fn signal_end_contour::Connection connect_emit_end_contour
       Connect to the emit end of outline signal
       \param o slot to call on emit end of contour signal
      */
-    boost::signals2::connection
-    connect_emit_end_contour(signal_end_contour::slot_type o)
+    signal_end_contour::Connection
+    connect_emit_end_contour(signal_end_contour::SlotType&& o)
     {
-      return m_o.connect(o);
+      return m_o.connect(std::move(o));
     }
 
   private:

--- a/src/fastuidraw/text/private/signal.hpp
+++ b/src/fastuidraw/text/private/signal.hpp
@@ -1,0 +1,107 @@
+/*!
+ * \file signal.hpp
+ * \brief file signal.hpp
+ *
+ * Copyright 2017 by Yusuke Suzuki.
+ *
+ * Contact: utatane.tea@gmail.com
+ *
+ * This Source Code Form is subject to the
+ * terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with
+ * this file, You can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ *
+ * \author Yusuke Suzuki <utatane.tea@gmail.com>
+ *
+ */
+
+
+#include <list>
+#include <memory>
+
+#include <fastuidraw/util/fastuidraw_memory.hpp>
+#include <fastuidraw/util/reference_count_non_concurrent.hpp>
+#include <fastuidraw/util/util.hpp>
+
+#pragma once
+
+namespace fastuidraw
+{
+
+/*!\class Signal
+  Simple Signal implementation.
+*/
+template<typename Function>
+class Signal:public noncopyable
+{
+public:
+  typedef Function SlotType;
+
+  class Slots:
+    public fastuidraw::reference_counted<Slots>::non_concurrent,
+    public std::list<SlotType>
+  {
+  };
+
+  Signal():
+    m_slots(FASTUIDRAWnew Slots())
+  { }
+
+  class Connection
+  {
+  public:
+    Connection(fastuidraw::reference_counted_ptr<Slots>& slots, typename Slots::iterator iterator):
+      m_slots(slots),
+      m_iterator(iterator)
+    { }
+
+    /*!
+      Disconnect the slot.
+     */
+    void
+    disconnect()
+    {
+        if(!m_slots)
+          {
+            return;
+          }
+        m_slots->erase(m_iterator);
+        m_slots = nullptr;
+    }
+
+  private:
+    fastuidraw::reference_counted_ptr<Slots> m_slots;
+    typename Slots::iterator m_iterator;
+  };
+
+  /*!
+    Call all the associated slots.
+   */
+  template<typename... Args>
+  void
+  operator()(Args... args)
+  {
+    for(auto& slot : *m_slots)
+      {
+        slot(args...);
+      }
+  }
+
+  /*!
+    Connect the slot and return the connection.
+   */
+  Connection
+  connect(SlotType&& slot)
+  {
+      m_slots->push_back(slot);
+      typename Slots::iterator iterator = m_slots->end();
+      --iterator;
+      return Connection { m_slots, iterator };
+  }
+
+private:
+  fastuidraw::reference_counted_ptr<Slots> m_slots;
+};
+
+}


### PR DESCRIPTION
With #14, we now drop all the boost dependencies.