### PR TITLE
fix missing inclusion <functional>

### DIFF
--- a/src/fastuidraw/text/private/freetype_util.hpp
+++ b/src/fastuidraw/text/private/freetype_util.hpp
@@ -32,6 +32,7 @@
 #include <map>
 #include <tuple>
 #include <vector>
+#include <functional>
 #include <sys/time.h>
 #include <unistd.h>
 #include <mutex>


### PR DESCRIPTION
Like the title says. Fixes `make demos` on Linux x86_64, gcc 7.1.1.