### PR TITLE
Initial CMake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+
+# CMake 3.10 is required for built-in EGL support in FindOpenGL
+# Could be lowered using a manual FindEGL.cmake, if needed
+cmake_minimum_required(VERSION 3.10.0)
+project(fastuidraw)
+
+set(FASTUIDRAW_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+include(cmake/functions.cmake)
+
+add_subdirectory(src/fastuidraw)
+
+option(FASTUIDRAW_DOC "Build documentation" ON)
+option(FASTUIDRAW_DEMOS "Build the demos" OFF)
+
+if(FASTUIDRAW_DOC)
+
+    # TODO: out-of-source documentation build
+
+    find_package(Doxygen REQUIRED)
+
+    set(DOCS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/docs")
+    set(INDEX_HTML "${DOCS_DIRECTORY}/doxy/html/index.html")
+
+    add_custom_command(
+        OUTPUT ${INDEX_HTML}
+        DEPENDS "${DOCS_DIRECTORY}/Doxyfile"
+        COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
+        COMMENT "Generating API documentation with Doxygen"
+        WORKING_DIRECTORY ${DOCS_DIRECTORY}
+        VERBATIM
+    )
+
+    add_custom_target(generate_documentation ALL DEPENDS ${INDEX_HTML})
+
+endif()
+
+if(FASTUIDRAW_DEMOS)
+    add_subdirectory(demos)
+endif()

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,0 +1,39 @@
+
+
+function(prepend_path OUTPUT PREFIX)
+
+    set(TEMP_LIST "")
+
+    foreach(PATH ${ARGN})
+        list(APPEND TEMP_LIST "${PREFIX}/${PATH}")
+    endforeach(PATH)
+
+    set(${OUTPUT} "${TEMP_LIST}" PARENT_SCOPE)
+
+endfunction(prepend_path)
+
+function(assemble_resource_string_sources RESOURCE_STRINGS OUTPUT)
+
+    set(TEMP_LIST "")
+
+    foreach(RESOURCE_STRING_FILE ${RESOURCE_STRINGS})
+
+        get_filename_component(BARE_NAME ${RESOURCE_STRING_FILE} NAME)
+
+        set(CPP_FILENAME "${BARE_NAME}.cpp")
+
+        add_custom_command(
+            OUTPUT ${CPP_FILENAME}
+            COMMAND shell_scripts/fastuidraw-create-resource-cpp-file.sh "${CMAKE_CURRENT_SOURCE_DIR}/${RESOURCE_STRING_FILE}" ${BARE_NAME} ${CMAKE_CURRENT_BINARY_DIR}
+            WORKING_DIRECTORY ${FASTUIDRAW_ROOT_DIR}
+            COMMENT "Generating ${CPP_FILENAME} from ${BARE_NAME}"
+            VERBATIM
+        )
+
+        list(APPEND TEMP_LIST ${CPP_FILENAME})
+
+    endforeach(RESOURCE_STRING_FILE)
+
+    set(${OUTPUT} "${TEMP_LIST}" PARENT_SCOPE)
+
+endfunction(assemble_resource_string_sources)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+project(demos)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake) # For FindSDL2_image.cmake
+
+add_subdirectory(common)
+
+add_subdirectory(atlas_tests/glyph_test)
+add_subdirectory(atlas_tests/gradient_test)
+add_subdirectory(atlas_tests/image_test)
+
+add_subdirectory(painter_cells)
+add_subdirectory(painter_clippath_test)
+add_subdirectory(painter_cliprect_test)
+add_subdirectory(painter_glyph_test)
+add_subdirectory(painter_path_test)
+add_subdirectory(painter_test)

--- a/demos/atlas_tests/glyph_test/CMakeLists.txt
+++ b/demos/atlas_tests/glyph_test/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+project(glyph_test)
+
+set(GLYPH_TEST_RESOURCE_STRINGS
+    shaders/glyph.vert.glsl.resource_string
+    shaders/coverage_glyph.frag.glsl.resource_string
+    shaders/distance_glyph.frag.glsl.resource_string
+    shaders/curvepair_glyph.frag.glsl.resource_string
+    shaders/glyph_atlas.vert.glsl.resource_string
+    shaders/glyph_atlas.frag.glsl.resource_string
+    shaders/perform_aa.frag.glsl.resource_string
+    shaders/gles_prec.frag.glsl.resource_string
+)
+
+assemble_resource_string_sources("${GLYPH_TEST_RESOURCE_STRINGS}" GLYPH_TEST_RESOURCE_STRING_SOURCES)
+add_custom_target(generate_glyph_test_resource_strings DEPENDS ${GLYPH_TEST_RESOURCE_STRING_SOURCES})
+
+add_executable(${PROJECT_NAME}
+    ${GLYPH_TEST_RESOURCE_STRING_SOURCES}
+    main.cpp
+)
+
+add_dependencies(${PROJECT_NAME} generate_glyph_test_resource_strings)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/atlas_tests/gradient_test/CMakeLists.txt
+++ b/demos/atlas_tests/gradient_test/CMakeLists.txt
@@ -1,0 +1,21 @@
+
+project(gradient_test)
+
+set(GRADIENT_TEST_RESOURCE_STRINGS
+    shaders/linear_gradient.vert.glsl.resource_string
+    shaders/linear_gradient.frag.glsl.resource_string
+    shaders/draw_pt.vert.glsl.resource_string
+    shaders/draw_pt.frag.glsl.resource_string
+)
+
+assemble_resource_string_sources("${GRADIENT_TEST_RESOURCE_STRINGS}" GRADIENT_TEST_RESOURCE_STRING_SOURCES)
+add_custom_target(generate_gradient_test_resource_strings DEPENDS ${GRADIENT_TEST_RESOURCE_STRING_SOURCES})
+
+add_executable(${PROJECT_NAME}
+    ${GRADIENT_TEST_RESOURCE_STRING_SOURCES}
+    main.cpp
+)
+
+add_dependencies(${PROJECT_NAME} generate_gradient_test_resource_strings)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/atlas_tests/image_test/CMakeLists.txt
+++ b/demos/atlas_tests/image_test/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+project(image_test)
+
+set(IMAGE_TEST_RESOURCE_STRINGS
+    shaders/layer_texture_blit.vert.glsl.resource_string
+    shaders/layer_texture_blit.frag.glsl.resource_string
+    shaders/atlas_image_blit.frag.glsl.resource_string
+    shaders/atlas_image_blit.vert.glsl.resource_string
+    shaders/detect_boundary.glsl.resource_string
+)
+
+assemble_resource_string_sources("${IMAGE_TEST_RESOURCE_STRINGS}" IMAGE_TEST_RESOURCE_STRING_SOURCES)
+add_custom_target(generate_image_test_resource_strings DEPENDS ${IMAGE_TEST_RESOURCE_STRING_SOURCES})
+
+add_executable(${PROJECT_NAME}
+    ${IMAGE_TEST_RESOURCE_STRING_SOURCES}
+    main.cpp
+)
+
+add_dependencies(${PROJECT_NAME} generate_image_test_resource_strings)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/cmake/FindSDL2_image.cmake
+++ b/demos/cmake/FindSDL2_image.cmake
@@ -1,0 +1,100 @@
+# Locate SDL_image library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_IMAGE_LIBRARIES, the name of the library to link against
+#   SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+#   SDL2_IMAGE_FOUND, if false, do not try to link against
+#   SDL2_IMAGE_VERSION_STRING - human-readable string containing the version of SDL_image
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+#   SDLIMAGE_LIBRARY (same value as SDL2_IMAGE_LIBRARIES)
+#   SDLIMAGE_INCLUDE_DIR (same value as SDL2_IMAGE_INCLUDE_DIRS)
+#   SDLIMAGE_FOUND (same value as SDL2_IMAGE_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+        HINTS
+        ENV SDL2IMAGEDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES SDL2
+        # path suffixes to search inside ENV{SDLDIR}
+        include/SDL2 include
+        PATHS ${SDL2_IMAGE_PATH}
+        )
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+    set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+find_library(SDL2_IMAGE_LIBRARY
+        NAMES SDL2_image
+        HINTS
+        ENV SDL2IMAGEDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+        PATHS ${SDL2_IMAGE_PATH}
+        )
+
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MAJOR "${SDL2_IMAGE_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MINOR "${SDL2_IMAGE_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_PATCH "${SDL2_IMAGE_VERSION_PATCH_LINE}")
+    set(SDL2_IMAGE_VERSION_STRING ${SDL2_IMAGE_VERSION_MAJOR}.${SDL2_IMAGE_VERSION_MINOR}.${SDL2_IMAGE_VERSION_PATCH})
+    unset(SDL2_IMAGE_VERSION_MAJOR_LINE)
+    unset(SDL2_IMAGE_VERSION_MINOR_LINE)
+    unset(SDL2_IMAGE_VERSION_PATCH_LINE)
+    unset(SDL2_IMAGE_VERSION_MAJOR)
+    unset(SDL2_IMAGE_VERSION_MINOR)
+    unset(SDL2_IMAGE_VERSION_PATCH)
+endif()
+
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
+        REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
+        VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+# for backward compatibility
+set(SDLIMAGE_LIBRARY ${SDL2_IMAGE_LIBRARIES})
+set(SDLIMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIRS})
+set(SDLIMAGE_FOUND ${SDL2_IMAGE_FOUND})
+
+mark_as_advanced(SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)

--- a/demos/common/CMakeLists.txt
+++ b/demos/common/CMakeLists.txt
@@ -1,0 +1,39 @@
+
+project(demos_common)
+
+add_library(${PROJECT_NAME}
+    generic_command_line.cpp
+    colorstop_command_line.cpp
+    sdl_benchmark.cpp
+    sdl_demo.cpp
+    sdl_painter_demo.cpp
+    PanZoomTracker.cpp
+    ImageLoader.cpp
+    read_colorstops.cpp
+    read_path.cpp
+    text_helper.cpp
+    PainterWidget.cpp
+    cycle_value.cpp
+    random.cpp
+    read_dash_pattern.cpp
+    egl_helper.cpp
+)
+
+# SDL2
+
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})
+
+# EGL (fixme: why is it required for the demos?)
+
+find_package(OpenGL REQUIRED COMPONENTS OpenGL EGL)
+target_link_libraries(${PROJECT_NAME} PUBLIC OpenGL::OpenGL OpenGL::EGL)
+
+# FastUIDraw
+target_include_directories(${PROJECT_NAME} PUBLIC FastUIDraw)
+target_link_libraries(${PROJECT_NAME} PUBLIC FastUIDraw)
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/demos/painter_cells/CMakeLists.txt
+++ b/demos/painter_cells/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+project(painter_cells)
+
+add_executable(${PROJECT_NAME} 
+    cell_group.cpp
+    cell.cpp
+    main.cpp
+    table.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/painter_clippath_test/CMakeLists.txt
+++ b/demos/painter_clippath_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+project(painter_clippath_test)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/painter_cliprect_test/CMakeLists.txt
+++ b/demos/painter_cliprect_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+project(painter_cliprect_test)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/painter_glyph_test/CMakeLists.txt
+++ b/demos/painter_glyph_test/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+project(painter_glyph_test)
+
+add_executable(${PROJECT_NAME} 
+    glyph_finder.cpp
+    main.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/painter_path_test/CMakeLists.txt
+++ b/demos/painter_path_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+project(painter_path_test)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/demos/painter_test/CMakeLists.txt
+++ b/demos/painter_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+project(painter_test)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC demos_common)

--- a/src/fastuidraw/CMakeLists.txt
+++ b/src/fastuidraw/CMakeLists.txt
@@ -1,0 +1,444 @@
+
+project(FastUIDraw)
+
+find_package(OpenGL REQUIRED)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Options
+
+option(FASTUIDRAW_GL_BACKEND "Use the GL backend" ON)
+option(FASTUIDRAW_GLES_BACKEND "Use the GLES backend" OFF)
+option(FASTUIDRAW_NEGL "Build NEGL" OFF)
+
+# FIXME: figure out why EQUAL doesn't work
+if("${FASTUIDRAW_GL_BACKEND}" STREQUAL "${FASTUIDRAW_GLES_BACKEND}")
+    message(FATAL_ERROR "You have to select either the GL or the GLES backend!")
+endif()
+
+set(GL_INCLUDEPATH "${OPENGL_INCLUDE_DIR}" CACHE STRING "Directory where GL/GLES headers are located")
+
+set(GL_DEFAULT_RAW_HEADER_FILES
+    GL/glcorearb.h
+)
+
+set(GL_RAW_HEADER_FILES "${GL_DEFAULT_RAW_HEADER_FILES}" CACHE STRING "GL header files")
+
+if(FASTUIDRAW_NEGL)
+
+    if(NOT OpenGL_EGL_FOUND)
+        message(FATAL_ERROR "EGL requested, but it's not available on the system.")
+    endif()
+
+    set(EGL_INCLUDEPATH "${OPENGL_EGL_INCLUDE_DIRS}" CACHE STRING "Directory where EGL headers are located")
+
+    set(EGL_DEFAULT_RAW_HEADER_FILES
+        EGL/egl.h
+        EGL/eglext.h
+    )
+
+    set(EGL_RAW_HEADER_FILES "${EGL_DEFAULT_RAW_HEADER_FILES}" CACHE STRING "EGL header files")
+
+endif()
+
+if(FASTUIDRAW_GLES_BACKEND)
+
+    set(GLES_DEFAULT_RAW_HEADER_FILES
+        GLES3/gl3platform.h
+        GLES3/gl3.h
+        GLES3/gl31.h
+        GLES3/gl32.h
+        GLES2/gl2ext.h
+    )
+
+    set(GLES_RAW_HEADER_FILES "${GLES_DEFAULT_RAW_HEADER_FILES}" CACHE STRING "GLES header files")
+
+endif()
+
+add_subdirectory(ngl_generator)
+
+# Sources
+
+if(FASTUIDRAW_GL_BACKEND)
+
+    set(NGL_GL_CPP ${FASTUIDRAW_ROOT_DIR}/src/fastuidraw/gl_backend/ngl_gl.cpp)
+    set(NGL_GL_HPP ${FASTUIDRAW_ROOT_DIR}/inc/fastuidraw/gl_backend/ngl_gl.hpp)
+
+    set(GL_BACKEND_NGL_SOURCES ${NGL_GL_HPP} ${NGL_GL_CPP})
+
+    prepend_path(GL_HEADER_FILES ${GL_INCLUDEPATH} ${GL_RAW_HEADER_FILES})
+
+    add_custom_command(
+        OUTPUT ${GL_BACKEND_NGL_SOURCES}
+        COMMAND filter ${GL_HEADER_FILES} > gl_filter_output.txt
+        COMMAND extractor macro_prefix=FASTUIDRAWgl namespace=fastuidraw::gl_binding path=${GL_INCLUDEPATH} output_cpp=${NGL_GL_CPP} output_hpp=${NGL_GL_HPP} ${GL_RAW_HEADER_FILES} < gl_filter_output.txt
+        WORKING_DIRECTORY ${FASTUIDRAW_ROOT_DIR}
+        COMMENT "Generating NGL sources for GL"
+        VERBATIM
+    )
+
+    add_custom_target(ngl_generate_gl DEPENDS ${GL_BACKEND_NGL_SOURCES})
+
+elseif(FASTUIDRAW_GLES_BACKEND)
+
+    set(NGL_GLES_CPP ${FASTUIDRAW_ROOT_DIR}/src/fastuidraw/gl_backend/ngl_gles3.cpp)
+    set(NGL_GLES_HPP ${FASTUIDRAW_ROOT_DIR}/inc/fastuidraw/gl_backend/ngl_gles3.hpp)
+
+    set(GL_BACKEND_NGLES_SOURCES ${NGL_GLES_HPP} ${NGL_GLES_CPP})
+
+    prepend_path(GLES_HEADER_FILES ${GL_INCLUDEPATH} ${GLES_RAW_HEADER_FILES})
+
+    add_custom_command(
+        OUTPUT ${GL_BACKEND_NGLES_SOURCES}
+        COMMAND filter ${GLES_HEADER_FILES} > gles_filter_output.txt
+        COMMAND extractor macro_prefix=FASTUIDRAWgl namespace=fastuidraw::gl_binding path=${GL_INCLUDEPATH} output_cpp=${NGL_GLES_CPP} output_hpp=${NGL_GLES_HPP} ${GLES_RAW_HEADER_FILES} < gles_filter_output.txt
+        WORKING_DIRECTORY ${FASTUIDRAW_ROOT_DIR}
+        COMMENT "Generating NGL sources for GLES"
+        VERBATIM
+    )
+
+    add_custom_target(ngl_generate_gles DEPENDS ${GL_BACKEND_NGLES_SOURCES})
+
+endif()
+
+# gl_backend
+
+set(GL_BACKEND_NGL_COMMON_SOURCES
+    gl_backend/gl_binding.cpp
+)
+
+set(GL_BACKEND_PRIVATE_SOURCES
+    gl_backend/private/tex_buffer.cpp
+    gl_backend/private/texture_gl.cpp
+    gl_backend/private/texture_view.cpp
+)
+
+set(GL_BACKEND_RESOURCE_STRINGS
+    gl_backend/shaders/fastuidraw_painter_gles_precision.glsl.resource_string
+)
+
+set(GL_BACKEND_SOURCES
+    ${GL_BACKEND_NGL_COMMON_SOURCES}
+    ${GL_BACKEND_PRIVATE_SOURCES}
+    ${GL_BACKEND_RESOURCE_STRINGS}
+
+    gl_backend/gl_get.cpp
+    gl_backend/opengl_trait.cpp
+    gl_backend/gluniform_implement.cpp
+    gl_backend/gl_program.cpp
+    gl_backend/gl_context_properties.cpp
+    gl_backend/image_gl.cpp
+    gl_backend/colorstop_atlas_gl.cpp
+    gl_backend/glyph_atlas_gl.cpp
+    gl_backend/painter_backend_gl.cpp
+)
+
+if(FASTUIDRAW_GL_BACKEND)
+    list(APPEND GL_BACKEND_SOURCES ${GL_BACKEND_NGL_SOURCES})
+elseif(FASTUIDRAW_GLES_BACKEND)
+    list(APPEND GL_BACKEND_SOURCES ${GL_BACKEND_NGLES_SOURCES})
+endif()
+
+# NEGL
+
+if(FASTUIDRAW_NEGL)
+
+    set(NGL_EGL_CPP ${FASTUIDRAW_ROOT_DIR}/src/fastuidraw/ngl_egl.cpp)
+    set(NGL_EGL_HPP ${FASTUIDRAW_ROOT_DIR}/inc/fastuidraw/ngl_egl.hpp)
+
+    set(NEGL_SOURCES ${NGL_EGL_HPP} ${NGL_EGL_CPP})
+
+    prepend_path(EGL_HEADER_FILES ${EGL_INCLUDEPATH} ${EGL_RAW_HEADER_FILES})
+
+    add_custom_command(
+        OUTPUT ${NEGL_SOURCES}
+        COMMAND filter ${EGL_HEADER_FILES} > egl_filter_output.txt
+        COMMAND extractor macro_prefix=FASTUIDRAWegl namespace=fastuidraw::egl_binding path=${EGL_INCLUDEPATH} output_cpp=${NGL_EGL_CPP} output_hpp=${NGL_EGL_HPP} ${EGL_RAW_HEADER_FILES} < egl_filter_output.txt
+        WORKING_DIRECTORY ${FASTUIDRAW_ROOT_DIR}
+        COMMENT "Generating NGL sources for EGL"
+        VERBATIM
+    )
+
+    add_custom_target(ngl_generate_egl DEPENDS ${NEGL_SOURCES})
+
+    list(APPEND NEGL_SOURCES egl_binding.cpp)
+
+endif()
+
+# glsl
+
+set(GLSL_PRIVATE_SOURCES
+    glsl/private/backend_shaders.cpp
+    glsl/private/uber_shader_builder.cpp
+)
+
+set(GLSL_PAINTER_BLEND_DUAL_SRC_RESOURCE_STRINGS
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_clear.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_dst_out.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_src_in.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_dst_atop.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_dst_over.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_src_out.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_dst.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_src_atop.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_src_over.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_dst_in.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_src.glsl.resource_string
+    glsl/shaders/painter/blend/dual_src/fastuidraw_porter_duff_xor.glsl.resource_string
+)
+
+set(GLSL_PAINTER_BLEND_FRAMEBUFFER_FETCH_RESOURCE_STRINGS
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_clear.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_dst_out.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_src_in.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_dst_atop.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_dst_over.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_src_out.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_dst.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_src_atop.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_src_over.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_dst_in.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_src.glsl.resource_string
+    glsl/shaders/painter/blend/framebuffer_fetch/fastuidraw_fbf_porter_duff_xor.glsl.resource_string
+)
+
+set(GLSL_PAINTER_BLEND_SINGLE_SRC_RESOURCE_STRINGS
+    glsl/shaders/painter/blend/single_src/fastuidraw_fall_through.glsl.resource_string
+)
+
+set(GLSL_PAINTER_BLEND_RESOURCE_STRINGS
+    ${GLSL_PAINTER_BLEND_DUAL_SRC_RESOURCE_STRINGS}
+    ${GLSL_PAINTER_BLEND_FRAMEBUFFER_FETCH_RESOURCE_STRINGS}
+    ${GLSL_PAINTER_BLEND_SINGLE_SRC_RESOURCE_STRINGS}
+)
+
+set(GLSL_PAINTER_BRUSH_RESOURCE_STRINGS
+    glsl/shaders/painter/brush/fastuidraw_painter_brush.vert.glsl.resource_string
+    glsl/shaders/painter/brush/fastuidraw_painter_brush_types.glsl.resource_string
+    glsl/shaders/painter/brush/fastuidraw_painter_brush_unpack.glsl.resource_string
+    glsl/shaders/painter/brush/fastuidraw_painter_brush_unpack_forward_declares.glsl.resource_string
+    glsl/shaders/painter/brush/fastuidraw_painter_brush_macros.glsl.resource_string
+    glsl/shaders/painter/brush/fastuidraw_painter_brush.frag.glsl.resource_string
+)
+
+set(GLSL_PAINTER_GLYPH_RESOURCE_STRINGS
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_coverage.vert.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_coverage.frag.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_distance_field.vert.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_distance_field.frag.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_distance_field_anisotropic.frag.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_curve_pair.vert.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_curve_pair.frag.glsl.resource_string
+    glsl/shaders/painter/glyph/fastuidraw_painter_glyph_curve_pair_anisotropic.frag.glsl.resource_string
+)
+
+set(GLSL_PAINTER_RESOURCE_STRINGS
+    ${GLSL_PAINTER_BLEND_RESOURCE_STRINGS}
+    ${GLSL_PAINTER_BRUSH_RESOURCE_STRINGS}
+    ${GLSL_PAINTER_GLYPH_RESOURCE_STRINGS}
+
+    glsl/shaders/painter/fastuidraw_painter_main.vert.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_types.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_forward_declares.vert.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_uniforms.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_forward_declares.frag.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_main.frag.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_stroke.vert.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_stroke.frag.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_fill.vert.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_fill.frag.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_fill_aa_fuzz.vert.glsl.resource_string
+    glsl/shaders/painter/fastuidraw_painter_fill_aa_fuzz.frag.glsl.resource_string
+)
+
+set(GLSL_RESOURCE_STRINGS
+    ${GLSL_PAINTER_RESOURCE_STRINGS}
+
+    glsl/shaders/fastuidraw_atlas_image_fetch.glsl.resource_string
+    glsl/shaders/fastuidraw_curvepair_glyph.frag.glsl.resource_string
+    glsl/shaders/fastuidraw_curvepair_glyph_derivative.frag.glsl.resource_string
+    glsl/shaders/fastuidraw_circular_interpolate.glsl.resource_string
+    glsl/shaders/fastuidraw_anisotropic.frag.glsl.resource_string
+    glsl/shaders/fastuidraw_unpack_unit_vector.glsl.resource_string
+    glsl/shaders/fastuidraw_align.vert.glsl.resource_string
+    glsl/shaders/fastuidraw_compute_local_distance_from_pixel_distance.glsl.resource_string
+)
+
+set(GLSL_SOURCES
+    ${GLSL_PRIVATE_SOURCES}
+    ${GLSL_RESOURCE_STRINGS}
+
+    glsl/shader_source.cpp
+    glsl/shader_code.cpp
+    glsl/painter_item_shader_glsl.cpp
+    glsl/painter_blend_shader_glsl.cpp
+    glsl/painter_backend_glsl.cpp
+)
+
+# private
+
+set(GLU_TESS_SOURCES
+    ../3rd_party/glu-tess/dict.cpp
+    ../3rd_party/glu-tess/geom.cpp
+    ../3rd_party/glu-tess/memalloc.cpp
+    ../3rd_party/glu-tess/mesh.cpp
+    ../3rd_party/glu-tess/priorityq.cpp
+    ../3rd_party/glu-tess/render.cpp
+    ../3rd_party/glu-tess/sweep.cpp
+    ../3rd_party/glu-tess/tess.cpp
+    ../3rd_party/glu-tess/tessmono.cpp
+)
+
+set(PRIVATE_SOURCES
+    ${GLU_TESS_SOURCES}
+
+    private/interval_allocator.cpp
+    private/path_util_private.cpp
+    private/clip.cpp
+    private/int_path.cpp
+)
+
+# painter
+
+set(PAINTER_PACKING_SOURCES
+    painter/packing/painter_backend.cpp
+    painter/packing/painter_draw.cpp
+    painter/packing/painter_packer.cpp
+)
+
+set(PAINTER_SOURCES
+    ${PAINTER_PACKING_SOURCES}
+
+    painter/fill_rule.cpp
+    painter/painter_attribute_data.cpp
+    painter/painter_attribute_data_filler_glyphs.cpp
+    painter/painter_brush.cpp
+    painter/painter_stroke_params.cpp
+    painter/painter_dashed_stroke_params.cpp
+    painter/painter.cpp
+    painter/painter_enums.cpp
+    painter/painter_shader_data.cpp
+    painter/painter_clip_equations.cpp
+    painter/painter_item_matrix.cpp
+    painter/painter_header.cpp
+    painter/painter_shader.cpp
+    painter/painter_shader_set.cpp
+    painter/painter_dashed_stroke_shader_set.cpp
+    painter/painter_stroke_shader.cpp
+    painter/painter_glyph_shader.cpp
+    painter/painter_blend_shader_set.cpp
+    painter/painter_fill_shader.cpp
+    painter/stroked_path.cpp
+    painter/filled_path.cpp
+)
+
+# text
+
+set(TEXT_PRIVATE_SOURCES
+    text/private/rect_atlas.cpp
+)
+
+set(TEXT_SOURCES
+    ${TEXT_PRIVATE_SOURCES}
+
+    text/glyph_atlas.cpp
+    text/glyph_render_data.cpp
+    text/glyph_render_data_curve_pair.cpp
+    text/glyph_render_data_distance_field.cpp
+    text/glyph_render_data_coverage.cpp
+    text/glyph_cache.cpp 
+    text/glyph_selector.cpp
+    text/freetype_face.cpp 
+    text/freetype_lib.cpp
+    text/font_freetype.cpp 
+    text/font_properties.cpp
+)
+
+# util
+
+set(UTIL_SOURCES
+    util/static_resource.cpp
+    util/fastuidraw_memory.cpp
+    util/util.cpp
+    util/blend_mode.cpp
+    util/reference_count_mutex.cpp
+    util/reference_count_atomic.cpp
+    util/pixel_distance_math.cpp
+    util/data_buffer.cpp
+    util/api_callback.cpp
+)
+
+# resource strings
+
+set(RESOURCE_STRINGS
+    ${GLSL_RESOURCE_STRINGS}
+    ${GL_BACKEND_RESOURCE_STRINGS}
+)
+
+assemble_resource_string_sources("${RESOURCE_STRINGS}" RESOURCE_STRING_SOURCES)
+add_custom_target(generate_fastuidraw_resource_strings DEPENDS ${RESOURCE_STRING_SOURCES})
+
+# all together
+
+set(SOURCES
+    ${GL_BACKEND_SOURCES}
+    ${GLSL_SOURCES}
+    ${PAINTER_SOURCES}
+    ${PRIVATE_SOURCES}
+    ${TEXT_SOURCES}
+    ${UTIL_SOURCES}
+    ${RESOURCE_STRING_SOURCES}
+
+    colorstop_atlas.cpp
+    colorstop.cpp
+    image.cpp
+    path.cpp
+    tessellated_path.cpp
+)
+
+if(FASTUIDRAW_NEGL)
+    list(APPEND SOURCES ${NEGL_SOURCES})
+endif()
+
+add_library(${PROJECT_NAME} SHARED ${SOURCES}) # TODO: static library if requested - it doesn't work with the static resource system currently (gets optimized away?)
+target_include_directories(${PROJECT_NAME} PUBLIC ${FASTUIDRAW_ROOT_DIR}/inc)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE GL_DEBUG)
+endif()
+
+# Dependencies
+
+find_package(Freetype REQUIRED)
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${FREETYPE_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${FREETYPE_LIBRARIES})
+
+# OpenGL binding dependencies
+
+if(FASTUIDRAW_GL_BACKEND)
+
+    add_dependencies(${PROJECT_NAME} ngl_generate_gl)
+
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${OPENGL_opengl_LIBRARY})
+
+elseif(FASTUIDRAW_GLES_BACKEND)
+
+    add_dependencies(${PROJECT_NAME} ngl_generate_gles)
+
+    target_compile_definitions(${PROJECT_NAME} PUBLIC FASTUIDRAW_GL_USE_GLES)
+    target_link_libraries(${PROJECT_NAME} PUBLIC GLESv2)
+
+endif()
+
+if(FASTUIDRAW_NEGL)
+
+    add_dependencies(${PROJECT_NAME} ngl_generate_egl)
+
+    target_include_directories(${PROJECT_NAME} PUBLIC ${OPENGL_EGL_INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${OPENGL_egl_LIBRARY})
+
+endif()
+
+add_dependencies(${PROJECT_NAME} generate_fastuidraw_resource_strings)

--- a/src/fastuidraw/ngl_generator/CMakeLists.txt
+++ b/src/fastuidraw/ngl_generator/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+project(ngl_generator)
+
+# filter
+
+add_executable(filter filter.cpp)
+
+# extractor
+
+find_package(FLEX REQUIRED)
+
+# Generate the output into the build directory
+flex_target(gl_flex gl_flex.fl.cpp ${CMAKE_CURRENT_BINARY_DIR}/gl_flex.cpp)
+
+add_executable(extractor ${FLEX_gl_flex_OUTPUTS} HeaderCreator.cpp)
+
+# Look for HeaderCreator.hpp in the source directory
+target_include_directories(extractor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
I've been hacking on CMake build support in the last few weeks. It has got to the point where the library, documentation and all demos build and run properly on my Linux desktop. With the GLES3 backend enabled there are some problems with the demos, but I haven't had the time yet to check if it's a driver issue or something with the build.

There are some subtle issues though. First, this initial version requires CMake 3.10 which isn't released yet. The reason is that only 3.10 will have a proper FindOpenGL.cmake built-in which can be used to check for EGL. This requirement can be lowered using a local FindEGL.cmake, if needed. Until then a locally built CMake can be used for testing.
Second, I couldn't chain the NGL filter to extractor through stdin/stdout as CMake doesn't seem to support that. The current workaround is to redirect one's output into a file and feed that into the other instead. This is incorrect as the redirection probably doesn't work on Windows. So either I'm wrong and the stdin/out chaining can be done with CMake or a separate shell/Python script will be needed later.
Third, given as I don't know the codebase in depth, it's possible that I missed some defines/build options or set them incorrectly, so they should be thoroughly checked.

Please review/test the changes. Only new files were added so the change is non-intrusive, the old and messy Makefile system can be thrown out later in a separate step.