### PR TITLE
Tolerate bash installed in a non-standard location

### DIFF
--- a/shell_scripts/fastuidraw-create-resource-cpp-file.sh
+++ b/shell_scripts/fastuidraw-create-resource-cpp-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Adapted from: create_cpp_from_string_resource.sh of WRATH:
 #


### PR DESCRIPTION
This is for OSs (e.g. NixOS) that doesn't put bash in a standard location.