### PR TITLE
Msvc fixes

### DIFF
--- a/demos/common/PanZoomTracker.cpp
+++ b/demos/common/PanZoomTracker.cpp
@@ -1,3 +1,4 @@
+#include <ciso646>
 #include "PanZoomTracker.hpp"
 
 /////////////////////////////////

--- a/demos/common/egl_helper.hpp
+++ b/demos/common/egl_helper.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef __WIN32
+#ifdef _WIN32
  #define EGL_HELPER_DISABLED
 #endif
 

--- a/demos/common/generic_command_line.hpp
+++ b/demos/common/generic_command_line.hpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <string>
 #include <sstream>
+#include <ciso646>
 #include <fastuidraw/util/util.hpp>
 
 class command_line_register;

--- a/demos/common/sdl_demo.hpp
+++ b/demos/common/sdl_demo.hpp
@@ -29,7 +29,9 @@
 #include <vector>
 
 #include <SDL.h>
+#ifndef _MSC_VER
 #include <sys/time.h>
+#endif
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>

--- a/demos/common/simple_time.hpp
+++ b/demos/common/simple_time.hpp
@@ -21,7 +21,14 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <WinSock2.h>
+#include <fastuidraw/util/time.hpp>
+#else
 #include <sys/time.h>
+#endif
 #include <stdint.h>
 
 class simple_time

--- a/demos/painter_cells/cell_group.cpp
+++ b/demos/painter_cells/cell_group.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "cell_group.hpp"
 
 void

--- a/demos/painter_cells/table.cpp
+++ b/demos/painter_cells/table.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "table.hpp"
 #include "cell.hpp"
 #include "random.hpp"

--- a/src/fastuidraw/colorstop_atlas.cpp
+++ b/src/fastuidraw/colorstop_atlas.cpp
@@ -18,6 +18,7 @@
 
 
 #include <vector>
+#include <algorithm>
 #include <fastuidraw/colorstop_atlas.hpp>
 #include "private/interval_allocator.hpp"
 #include "private/util_private.hpp"

--- a/src/fastuidraw/gl_backend/gl_program.cpp
+++ b/src/fastuidraw/gl_backend/gl_program.cpp
@@ -1940,7 +1940,7 @@ is_row_major(void) const
 {
   const ShaderVariableInfo *d;
   d = static_cast<const ShaderVariableInfo*>(m_d);
-  return (d) ? d->m_is_row_major : false;
+  return (d) ? (d->m_is_row_major != 0) : false;
 }
 
 GLint

--- a/src/fastuidraw/gl_backend/gl_program.cpp
+++ b/src/fastuidraw/gl_backend/gl_program.cpp
@@ -30,7 +30,13 @@
 #include <algorithm>
 #include <sstream>
 #include <stdint.h>
+#include <cctype>
+#ifdef _MSC_VER
+#include <Windows.h>
+#include <fastuidraw/util/time.hpp>
+#else
 #include <sys/time.h>
+#endif
 
 #include <fastuidraw/util/static_resource.hpp>
 #include <fastuidraw/gl_backend/ngl_header.hpp>

--- a/src/fastuidraw/gl_backend/gl_program.cpp
+++ b/src/fastuidraw/gl_backend/gl_program.cpp
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <stdint.h>
 #include <cctype>
+#include <ciso646>
 #ifdef _MSC_VER
 #include <Windows.h>
 #include <fastuidraw/util/time.hpp>

--- a/src/fastuidraw/glsl/painter_backend_glsl.cpp
+++ b/src/fastuidraw/glsl/painter_backend_glsl.cpp
@@ -18,6 +18,7 @@
 
 #include <sstream>
 #include <vector>
+#include <algorithm>
 
 #include <fastuidraw/glsl/painter_backend_glsl.hpp>
 #include <fastuidraw/painter/stroked_path.hpp>

--- a/src/fastuidraw/glsl/painter_item_shader_glsl.cpp
+++ b/src/fastuidraw/glsl/painter_item_shader_glsl.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <string>
 #include <list>
+#include <algorithm>
 #include <sstream>
 
 #include <fastuidraw/util/c_array.hpp>

--- a/src/fastuidraw/painter/filled_path.cpp
+++ b/src/fastuidraw/painter/filled_path.cpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <algorithm>
 #include <ctime>
+#include <set>
 #include <math.h>
 
 #include <fastuidraw/tessellated_path.hpp>

--- a/src/fastuidraw/painter/painter.cpp
+++ b/src/fastuidraw/painter/painter.cpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <bitset>
+#include <algorithm>
 
 #include <fastuidraw/util/math.hpp>
 #include <fastuidraw/painter/painter_header.hpp>

--- a/src/fastuidraw/painter/painter_dashed_stroke_params.cpp
+++ b/src/fastuidraw/painter/painter_dashed_stroke_params.cpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include <algorithm>
 #include <cmath>
 #include <fastuidraw/painter/painter_dashed_stroke_params.hpp>
 #include <fastuidraw/painter/stroked_path.hpp>

--- a/src/fastuidraw/private/interval_allocator.cpp
+++ b/src/fastuidraw/private/interval_allocator.cpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include <algorithm>
 
 #include <fastuidraw/util/util.hpp>
 #include "interval_allocator.hpp"

--- a/src/fastuidraw/private/interval_allocator.hpp
+++ b/src/fastuidraw/private/interval_allocator.hpp
@@ -137,7 +137,7 @@ namespace fastuidraw
     {
     public:
       bool
-      operator()(interval_ref lhs, interval_ref rhs)
+      operator()(interval_ref lhs, interval_ref rhs) const
       {
         FASTUIDRAWassert(lhs->first == lhs->second.m_end);
         FASTUIDRAWassert(rhs->first == rhs->second.m_end);

--- a/src/fastuidraw/tessellated_path.cpp
+++ b/src/fastuidraw/tessellated_path.cpp
@@ -19,6 +19,7 @@
 
 #include <list>
 #include <vector>
+#include <algorithm>
 #include <fastuidraw/tessellated_path.hpp>
 #include <fastuidraw/path.hpp>
 #include <fastuidraw/painter/stroked_path.hpp>

--- a/src/fastuidraw/text/glyph_render_data_curve_pair.cpp
+++ b/src/fastuidraw/text/glyph_render_data_curve_pair.cpp
@@ -16,6 +16,7 @@
  * \author Kevin Rogovin <kevin.rogovin@intel.com>
  */
 
+#include <ciso646>
 #include <vector>
 #include <fastuidraw/text/glyph_render_data_curve_pair.hpp>
 

--- a/src/fastuidraw/text/private/rect_atlas.cpp
+++ b/src/fastuidraw/text/private/rect_atlas.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <ciso646>
 
 #include "rect_atlas.hpp"
 


### PR DESCRIPTION
This series includes the fixes for compilation with MSVC on Windows. It can't be compiled with makefiles included yet, but with the cmake generated solution file, and it still depends on shell to generate the source files for the shader strings. But these fixes should be trivial enough.