### PR TITLE
fastuidraw/glsl/uber_shader_builder: fix compilation error

### DIFF
--- a/src/fastuidraw/internal/private/glsl/uber_shader_builder.cpp
+++ b/src/fastuidraw/internal/private/glsl/uber_shader_builder.cpp
@@ -18,6 +18,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <typeinfo>
 
 #include <private/glsl/uber_shader_builder.hpp>
 #include <private/util_private.hpp>


### PR DESCRIPTION
uber_shader_builder.cpp:184:61: error: must #include <typeinfo>
before using typeid