### PR TITLE
fastuidraw/gl_backend: typo fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,42 @@
 # this file, You can obtain one at
 # http://mozilla.org/MPL/2.0/.
 
+## Detect MINGW
+MINGW_BUILD = 0
+UNAME = $(shell uname -s)
+UNAMER= $(shell uname -r)
+ifeq ($(findstring MINGW,$(UNAME)),MINGW)
+  MINGW_BUILD = 1
+  ifeq ($(findstring 1.0, $(UNAMER)), 1.0)
+	MINGW_MODE = MINGW
+  else ifeq ($(findstring MINGW64,$(UNAME)),MINGW64)
+	MINGW_MODE = MINGW64
+  else ifeq ($(findstring MINGW32,$(UNAME)),MINGW32)
+	MINGW_MODE = MINGW32
+  endif
+endif
+
+## Detect Darwin (i.e. MacOS)
+DARWIN_BUILD = 0
+ifeq ($(UNAME),Darwin)
+  DARWIN_BUILD = 1
+endif
+
 # Compiler choice
 CXX ?= g++
 CC ?= gcc
+
+ECHO=$(shell which echo)
 
 # Lex choice
 LEX ?= flex
 
 # if demos will use font-config, only affects demos and not libs
-DEMOS_HAVE_FONT_CONFIG ?= 1
+ifeq ($(DARWIN_BUILD),0)
+  DEMOS_HAVE_FONT_CONFIG ?= 1
+else
+  DEMOS_HAVE_FONT_CONFIG ?= 0
+endif
 
 #Init TARGETLIST
 TARGETLIST := all

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Building requirements
  - perl
  - up to date GL (and GLES) headers
    - You need
-      - for GL, from https://www.opengl.org/registry/: GL/glcorearb.h
+      - for GL, from https://www.opengl.org/registry/: GL/glcorearb.h, KHR/khrplatform.h
       - for GLES, from https://www.khronos.org/registry/gles/: GLES2/gl2.h, GLES2/gl2ext.h, GLES3/gl3.h, GLES3/gl31.h, GLES3/gl32.h, KHR/khrplatform.h
    - The expected place of those headers is set by setting the
      environmental variable GL_INCLUDEPATH; if the value is not set,
@@ -70,6 +70,14 @@ Building
   "make targets" to see all build targets and the list of environmental
   variables that control what is built and how. On MS-Windows, the helper
   library NEGL is NOT built by default and on other platforms it is.
+
+  MacOS build is possible, but is NOT done with the GL headers that
+  are included in MacOS. Instead copy the needed Khronos headers
+  to /usr/local/include with the tree intact, i.e. copy GL/glcorearb.h
+  from the Khronos registry to /usr/local/include/GL/glcorearb.h and
+  copy KHR/khrplatform.h to /usr/local/include/KHR/khrplatform.h.
+  Then the build process will work (the build system defaults
+  GL_INCLUDEPATH to /usr/local/include on OS-X). Yes, this is a hack.
 
 Running Demos
 =============

--- a/demos/common/ImageLoader.hpp
+++ b/demos/common/ImageLoader.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_IMAGELOADER_HPP
+#define FASTUIDRAW_DEMO_IMAGELOADER_HPP
 
 #include <SDL_image.h>
 #include <vector>
@@ -78,3 +79,5 @@ public:
     fastuidraw::ImageSourceCArray(dimensions(), data(), fastuidraw::Image::rgba_format)
   {}
 };
+
+#endif

--- a/demos/common/PainterWidget.hpp
+++ b/demos/common/PainterWidget.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_PAINTERWIDGET_HPP
+#define FASTUIDRAW_DEMO_PAINTERWIDGET_HPP
 
 #include <list>
 #include <fastuidraw/util/reference_counted.hpp>
@@ -74,3 +75,5 @@ private:
   std::list<PainterWidget*>::iterator m_iterator_loc;
   std::list<PainterWidget*> m_children;
 };
+
+#endif

--- a/demos/common/PanZoomTracker.hpp
+++ b/demos/common/PanZoomTracker.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_PANZOOMTRACKER_HPP
+#define FASTUIDRAW_DEMO_PANZOOMTRACKER_HPP
 
 #include <SDL.h>
 #include "ScaleTranslate.hpp"
@@ -104,3 +105,5 @@ public:
    */
   fastuidraw::vec2 m_scale_event, m_translate_event;
 };
+
+#endif

--- a/demos/common/ScaleTranslate.hpp
+++ b/demos/common/ScaleTranslate.hpp
@@ -20,7 +20,8 @@
 
 
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_SCALETRANSLATE_HPP
+#define FASTUIDRAW_DEMO_SCALETRANSLATE_HPP
 
 #include <cstdlib>
 #include <fastuidraw/util/util.hpp>
@@ -243,3 +244,5 @@ operator*(const ScaleTranslate<T> &a, const ScaleTranslate<T> &b)
 }
 
 /*! @} */
+
+#endif

--- a/demos/common/bounding_box.hpp
+++ b/demos/common/bounding_box.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_BOUNDING_BOX_HPP
+#define FASTUIDRAW_DEMO_BOUNDING_BOX_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 
@@ -171,3 +172,5 @@ private:
   pt_type m_min, m_max;
   bool m_empty;
 };
+
+#endif

--- a/demos/common/cast_c_array.hpp
+++ b/demos/common/cast_c_array.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_CAST_C_ARRAY_HPP
+#define FASTUIDRAW_DEMO_CAST_C_ARRAY_HPP
 
 #include <vector>
 #include <fastuidraw/util/c_array.hpp>
@@ -29,3 +30,5 @@ cast_c_array(std::vector<T> &p)
     fastuidraw::c_array<T>() :
     fastuidraw::c_array<T>(&p[0], p.size());
 }
+
+#endif

--- a/demos/common/colorstop_command_line.hpp
+++ b/demos/common/colorstop_command_line.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_COLORSTOP_COMMAND_LINE_HPP
+#define FASTUIDRAW_DEMO_COLORSTOP_COMMAND_LINE_HPP
 
 #include <string>
 #include <map>
@@ -56,3 +57,5 @@ private:
   hoard m_values;
   std::string m_add, m_add2, m_disc;
 };
+
+#endif

--- a/demos/common/command_line_list.hpp
+++ b/demos/common/command_line_list.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_COMMAND_LINE_LIST_HPP
+#define FASTUIDRAW_DEMO_COMMAND_LINE_LIST_HPP
 
 #include <set>
 #include "generic_command_line.hpp"
@@ -55,3 +56,5 @@ public:
 private:
   std::string m_name, m_description;
 };
+
+#endif

--- a/demos/common/cycle_value.hpp
+++ b/demos/common/cycle_value.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_CYCLE_VALUE_HPP
+#define FASTUIDRAW_DEMO_CYCLE_VALUE_HPP
 
 void
 cycle_value(unsigned int &value, bool decrement, unsigned int limit_value);
@@ -11,3 +12,5 @@ cycle_value(T &value, bool decrement, unsigned int limit_value)
   cycle_value(v, decrement, limit_value);
   value = T(v);
 }
+
+#endif

--- a/demos/common/generic_command_line.hpp
+++ b/demos/common/generic_command_line.hpp
@@ -30,7 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /** \file generic_command_line.hpp */
-#pragma once
+#ifndef FASTUIDRAW_DEMO_GENERIC_COMMAND_LINE_HPP
+#define FASTUIDRAW_DEMO_GENERIC_COMMAND_LINE_HPP
 
 #include <iostream>
 #include <vector>
@@ -657,3 +658,5 @@ private:
   bool m_set_by_command_line, m_print_at_set;
   enumerated_type<T> m_value;
 };
+
+#endif

--- a/demos/common/generic_hierarchy.hpp
+++ b/demos/common/generic_hierarchy.hpp
@@ -4,7 +4,8 @@
 
 #include "bounding_box.hpp"
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_GENERIC_HIERARCHY_HPP
+#define FASTUIDRAW_DEMO_GENERIC_HIERARCHY_HPP
 
 class GenericHierarchy:fastuidraw::noncopyable
 {
@@ -31,3 +32,5 @@ public:
 private:
   void *m_root;
 };
+
+#endif

--- a/demos/common/ostream_utility.hpp
+++ b/demos/common/ostream_utility.hpp
@@ -19,7 +19,8 @@
 
 
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_OSTREAM_UTILITY_HPP
+#define FASTUIDRAW_DEMO_OSTREAM_UTILITY_HPP
 
 
 #include <iostream>
@@ -379,3 +380,5 @@ operator<<(std::ostream &str, const fastuidraw::matrixNxM<N, M, T> &matrix)
 
 
 /*! @} */
+
+#endif

--- a/demos/common/path_util.hpp
+++ b/demos/common/path_util.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_PATH_UTIL_HPP
+#define FASTUIDRAW_DEMO_PATH_UTIL_HPP
 
 #include <string>
 #include <vector>
@@ -10,3 +11,5 @@ extract_path_info(const fastuidraw::Path &path,
                   std::vector<fastuidraw::vec2> *out_crl_pts,
                   std::vector<fastuidraw::vec2> *out_arc_center_pts,
                   std::string *path_text);
+
+#endif

--- a/demos/common/print_utils.hpp
+++ b/demos/common/print_utils.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_PRINT_UTILS_HPP
+#define FASTUIDRAW_DEMO_PRINT_UTILS_HPP
 
 #include <iostream>
 #include <stdint.h>
@@ -74,3 +75,5 @@ operator<<(std::ostream &str, const PrintBytes &obj)
     }
   return str;
 }
+
+#endif

--- a/demos/common/random.hpp
+++ b/demos/common/random.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_RANDOM_HPP
+#define FASTUIDRAW_DEMO_RANDOM_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 
@@ -16,3 +17,5 @@ random_value(fastuidraw::vecN<float, N> pmin, fastuidraw::vecN<float, N> pmax)
     }
   return return_value;
 }
+
+#endif

--- a/demos/common/read_colorstops.hpp
+++ b/demos/common/read_colorstops.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_READ_COLORSTOPS_HPP
+#define FASTUIDRAW_DEMO_READ_COLORSTOPS_HPP
 
 #include <istream>
 #include <fastuidraw/colorstop.hpp>
@@ -14,3 +15,5 @@ and the value red, green, blue and alpha are integers in the range [0,255]
  */
 void
 read_colorstops(fastuidraw::ColorStopArray &seq, std::istream &input);
+
+#endif

--- a/demos/common/read_dash_pattern.hpp
+++ b/demos/common/read_dash_pattern.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_READ_DASH_PATTERN_HPP
+#define FASTUIDRAW_DEMO_READ_DASH_PATTERN_HPP
 
 #include <istream>
 #include <vector>
@@ -7,3 +8,5 @@
 void
 read_dash_pattern(std::vector<fastuidraw::PainterDashedStrokeParams::DashPatternElement> &pattern_out,
                   std::istream &input_stream);
+
+#endif

--- a/demos/common/read_path.hpp
+++ b/demos/common/read_path.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_READ_PATH_HPP
+#define FASTUIDRAW_DEMO_READ_PATH_HPP
 
 #include <string>
 #include <fastuidraw/path.hpp>
@@ -18,3 +19,5 @@
 void
 read_path(fastuidraw::Path &path, const std::string &source,
           std::string *dst_cpp_code = nullptr);
+
+#endif

--- a/demos/common/sdl_demo.cpp
+++ b/demos/common/sdl_demo.cpp
@@ -382,7 +382,13 @@ enum fastuidraw::return_code
 sdl_demo::
 init_sdl(void)
 {
-  if (SDL_Init(SDL_INIT_EVERYTHING)<0)
+  #ifdef _WIN32
+    {
+      SetProcessDPIAware();
+    }
+  #endif
+  
+  if (SDL_Init(SDL_INIT_EVERYTHING) < 0)
     {
       std::cerr << "\nFailed on SDL_Init\n";
       return fastuidraw::routine_fail;
@@ -536,7 +542,7 @@ main(int argc, char **argv)
   simple_time render_time;
   unsigned int num_frames;
 
-  if (argc == 2 and is_help_request(argv[1]))
+  if (argc == 2 && is_help_request(argv[1]))
     {
       std::cout << m_about << "\n\nUsage: " << argv[0];
       print_help(std::cout);

--- a/demos/common/sdl_demo.hpp
+++ b/demos/common/sdl_demo.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_SDL_DEMO_HPP
+#define FASTUIDRAW_DEMO_SDL_DEMO_HPP
 
 #include <iostream>
 #include <iomanip>
@@ -166,3 +167,5 @@ private:
   SDL_Window *m_window;
   SDL_GLContext m_ctx;
 };
+
+#endif

--- a/demos/common/simple_time.hpp
+++ b/demos/common/simple_time.hpp
@@ -19,7 +19,8 @@
 
 
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_SIMPLE_TIME_HPP
+#define FASTUIDRAW_DEMO_SIMPLE_TIME_HPP
 
 #include <chrono>
 
@@ -83,3 +84,5 @@ private:
 
   std::chrono::time_point<std::chrono::steady_clock> m_start_time;
 };
+
+#endif

--- a/demos/common/simple_time_circular_array.hpp
+++ b/demos/common/simple_time_circular_array.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_SIMPLE_TIME_CIRCULAR_ARRAY_HPP
+#define FASTUIDRAW_DEMO_SIMPLE_TIME_CIRCULAR_ARRAY_HPP
 
 #include "simple_time.hpp"
 #include <fastuidraw/util/vecN.hpp>
@@ -88,3 +89,5 @@ private:
   int m_current, m_total;
   fastuidraw::vecN<simple_time, N + 1u> m_times;
 };
+
+#endif

--- a/demos/common/stream_holder.hpp
+++ b/demos/common/stream_holder.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_STREAM_HOLDER_HPP
+#define FASTUIDRAW_DEMO_STREAM_HOLDER_HPP
 
 #include <ostream>
 #include <string>
@@ -20,3 +21,5 @@ private:
   std::ostream *m_stream;
   bool m_delete_stream;
 };
+
+#endif

--- a/demos/common/text_helper.cpp
+++ b/demos/common/text_helper.cpp
@@ -490,6 +490,10 @@ default_font(void)
     {
       return "C:/Windows/Fonts/arial.ttf";
     }
+  #elif defined(__APPLE__)
+    {
+      return "/Library/Fonts/Arial.ttf";
+    }
   #else
     {
       return "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
@@ -503,6 +507,10 @@ default_font_path(void)
   #ifdef _WIN32
     {
       return "C:/Windows/Fonts";
+    }
+  #elif defined(__APPLE__)
+    {
+      return "/Library/Fonts/";
     }
   #else
     {

--- a/demos/common/text_helper.hpp
+++ b/demos/common/text_helper.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_TEXT_HELPER_HPP
+#define FASTUIDRAW_DEMO_TEXT_HELPER_HPP
 
 #include <vector>
 #include <set>
@@ -120,3 +121,5 @@ default_font(void);
 
 fastuidraw::c_string
 default_font_path(void);
+
+#endif

--- a/demos/painter_cells/cell.hpp
+++ b/demos/painter_cells/cell.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_CELL_HPP
+#define FASTUIDRAW_DEMO_CELL_HPP
 
 #include <fastuidraw/text/font_database.hpp>
 #include <fastuidraw/text/glyph_cache.hpp>
@@ -104,3 +105,5 @@ private:
   CellSharedState *m_shared_state;
   bool m_timer_based_animation;
 };
+
+#endif

--- a/demos/painter_cells/cell_group.hpp
+++ b/demos/painter_cells/cell_group.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_CELL_GROUP_HPP
+#define FASTUIDRAW_DEMO_CELL_GROUP_HPP
 
 #include "ostream_utility.hpp"
 #include "PainterWidget.hpp"
@@ -28,3 +29,5 @@ protected:
   pre_paint(void);
 
 };
+
+#endif

--- a/demos/painter_cells/table.hpp
+++ b/demos/painter_cells/table.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_DEMO_TABLE_HPP
+#define FASTUIDRAW_DEMO_TABLE_HPP
 
 #include <fastuidraw/text/font_database.hpp>
 #include <fastuidraw/text/glyph_cache.hpp>
@@ -89,3 +90,5 @@ private:
   int m_thousandths_degrees_rotation;
   float m_rotation_radians;
 };
+
+#endif

--- a/demos/tutorial/common/demo_framework.hpp
+++ b/demos/tutorial/common/demo_framework.hpp
@@ -15,7 +15,8 @@
  * \author Kevin Rogovin <kevin.rogovin@gmail.com>
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_DEMO_FRAMEWORK_HPP
+#define FASTUIDRAW_DEMO_DEMO_FRAMEWORK_HPP
 
 //! [ExampleFramework]
 
@@ -124,3 +125,5 @@ private:
 };
 
 //! [ExampleFramework]
+
+#endif

--- a/demos/tutorial/common/image_loader.hpp
+++ b/demos/tutorial/common/image_loader.hpp
@@ -15,7 +15,8 @@
  * \author Kevin Rogovin <kevin.rogovin@gmail.com>
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DEMO_IMAGE_LOADER_HPP
+#define FASTUIDRAW_DEMO_IMAGE_LOADER_HPP
 
 //! [ExampleImage]
 
@@ -137,3 +138,5 @@ private:
 };
 
 //! [ExampleImage]
+
+#endif

--- a/inc/fastuidraw/colorstop.hpp
+++ b/inc/fastuidraw/colorstop.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_COLORSTOP_HPP
+#define FASTUIDRAW_COLORSTOP_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -202,3 +203,5 @@ class ColorStopAtlas;
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/colorstop_atlas.hpp
+++ b/inc/fastuidraw/colorstop_atlas.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_COLORSTOP_ATLAS_HPP
+#define FASTUIDRAW_COLORSTOP_ATLAS_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/colorstop.hpp>
@@ -236,3 +237,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/gl_backend/gl_binding.hpp
+++ b/inc/fastuidraw/gl_backend/gl_binding.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GL_BINDING_HPP
+#define FASTUIDRAW_GL_BINDING_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/api_callback.hpp>
@@ -140,3 +141,5 @@ message(c_string message, c_string src_file, int src_line);
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/gl_backend/gl_context_properties.hpp
+++ b/inc/fastuidraw/gl_backend/gl_context_properties.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GL_CONTEXT_PROPERTIES_HPP
+#define FASTUIDRAW_GL_CONTEXT_PROPERTIES_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -101,3 +102,5 @@ namespace fastuidraw
 /*! @} */
   }
 }
+
+#endif

--- a/inc/fastuidraw/gl_backend/gl_get.hpp
+++ b/inc/fastuidraw/gl_backend/gl_get.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GL_GET_HPP
+#define FASTUIDRAW_GL_GET_HPP
 
 
 #include <fastuidraw/gl_backend/gl_header.hpp>
@@ -109,3 +110,5 @@ context_get(GLenum value)
 
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/gl_backend/gl_program.hpp
+++ b/inc/fastuidraw/gl_backend/gl_program.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GL_PROGRAM_HPP
+#define FASTUIDRAW_GL_PROGRAM_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -1731,3 +1732,5 @@ private:
 
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/gl_backend/gluniform.hpp
+++ b/inc/fastuidraw/gl_backend/gluniform.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLUNIFORM_HPP
+#define FASTUIDRAW_GLUNIFORM_HPP
 
 #include <fastuidraw/gl_backend/gl_header.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -327,3 +328,5 @@ ProgramUniform(GLuint program, int location, c_array<const T> v)
 
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/gl_backend/gluniform_implement.hpp
+++ b/inc/fastuidraw/gl_backend/gluniform_implement.hpp
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLUNIFORM_IMPLEMENT_HPP
+#define FASTUIDRAW_GLUNIFORM_IMPLEMENT_HPP
 
 #include <fastuidraw/gl_backend/gl_header.hpp>
 
@@ -180,3 +181,5 @@ MACRO_IMPLEMENT_GL_UNIFORM_MATRIX_IMPL(f, GLfloat)
 
 }
 }
+
+#endif

--- a/inc/fastuidraw/gl_backend/painter_engine_gl.hpp
+++ b/inc/fastuidraw/gl_backend/painter_engine_gl.hpp
@@ -416,21 +416,6 @@ namespace fastuidraw
         ivec2
         texture_2d_array_store_log2_dims(void) const;
 
-	/*!
-	 * If false, the shader will have two sources for the data of the
-	 * glyph atlas: one formatted as an array of uint32_t and the other
-	 * formatted as an array of fp16s.
-	 */
-	bool
-	use_unpack(void) const;
-
-        /*!
-         * Set the value returned by use_unpack(void) const.
-         * Default value is false.
-         */
-        GlyphAtlasParams&
-        use_unpack(bool);
-
         /*!
          * Query the GL context to decide what is the optimal settings
          * to back the GlyphAtlasBackingStoreBase returned by
@@ -614,6 +599,12 @@ namespace fastuidraw
          */
         ConfigurationGL&
         clipping_type(enum clipping_type_t);
+
+	bool
+	use_glsl_unpack_fp16(void) const;
+
+	ConfigurationGL&
+	use_glsl_unpack_fp16(bool);
 
         /*!
          * Returns the number of external textures (realized as

--- a/inc/fastuidraw/gl_backend/painter_engine_gl.hpp
+++ b/inc/fastuidraw/gl_backend/painter_engine_gl.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ENGINE_GL_HPP
+#define FASTUIDRAW_PAINTER_ENGINE_GL_HPP
 
 #include <fastuidraw/painter/backend/painter_engine.hpp>
 #include <fastuidraw/glsl/painter_shader_registrar_glsl.hpp>
@@ -999,3 +1000,5 @@ namespace fastuidraw
 /*! @} */
   }
 }
+
+#endif

--- a/inc/fastuidraw/gl_backend/painter_surface_gl.hpp
+++ b/inc/fastuidraw/gl_backend/painter_surface_gl.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SURFACE_GL_HPP
+#define FASTUIDRAW_PAINTER_SURFACE_GL_HPP
 
 #include <fastuidraw/painter/backend/painter_surface.hpp>
 #include <fastuidraw/gl_backend/gl_header.hpp>
@@ -162,3 +163,5 @@ namespace fastuidraw
 /*! @} */
   }
 }
+
+#endif

--- a/inc/fastuidraw/gl_backend/texture_image_gl.hpp
+++ b/inc/fastuidraw/gl_backend/texture_image_gl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_TEXTURE_IMAGE_GL_HPP
+#define FASTUIDRAW_TEXTURE_IMAGE_GL_HPP
 
 #include <fastuidraw/image.hpp>
 #include <fastuidraw/image_atlas.hpp>
@@ -145,3 +146,5 @@ namespace gl
 
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/glsl/painter_blend_shader_glsl.hpp
+++ b/inc/fastuidraw/glsl/painter_blend_shader_glsl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BLEND_SHADER_GLSL_HPP
+#define FASTUIDRAW_PAINTER_BLEND_SHADER_GLSL_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/blend_mode.hpp>
@@ -200,3 +201,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/painter_brush_shader_glsl.hpp
+++ b/inc/fastuidraw/glsl/painter_brush_shader_glsl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BRUSH_SHADER_GLSL_HPP
+#define FASTUIDRAW_PAINTER_BRUSH_SHADER_GLSL_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/blend_mode.hpp>
@@ -281,3 +282,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/painter_item_shader_glsl.hpp
+++ b/inc/fastuidraw/glsl/painter_item_shader_glsl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ITEM_SHADER_GLSL_HPP
+#define FASTUIDRAW_PAINTER_ITEM_SHADER_GLSL_HPP
 
 #include <fastuidraw/painter/shader/painter_item_shader.hpp>
 #include <fastuidraw/glsl/shader_source.hpp>
@@ -535,3 +536,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/painter_shader_registrar_glsl.hpp
+++ b/inc/fastuidraw/glsl/painter_shader_registrar_glsl.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_REGISTRAR_GLSL_HPP
+#define FASTUIDRAW_PAINTER_SHADER_REGISTRAR_GLSL_HPP
 
 #include <fastuidraw/painter/backend/painter_shader_registrar.hpp>
 #include <fastuidraw/painter/backend/painter_engine.hpp>
@@ -1118,3 +1119,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/painter_shader_registrar_glsl.hpp
+++ b/inc/fastuidraw/glsl/painter_shader_registrar_glsl.hpp
@@ -470,21 +470,6 @@ namespace fastuidraw
         UberShaderParams&
         glyph_data_backing_log2_dims(ivec2);
 
-	/*!
-	 * If false, the shader will have two sources for the data of the
-	 * glyph atlas: one formatted as an array of uint32_t and the other
-	 * formatted as an array of fp16s.
-	 */
-	bool
-	glyph_data_backing_use_unpack(void) const;
-
-        /*!
-         * Set the value returned by glyph_data_backing_use_unpack(void) const.
-         * Default value is false.
-         */
-        UberShaderParams&
-        glyph_data_backing_use_unpack(bool);
-
         /*!
          * Specifies how the bakcing store to the color stop atlas
          * (ColorStopAtlas::backing_store()) is accessed from the
@@ -593,15 +578,6 @@ namespace fastuidraw
          */
         int
         glyph_atlas_store_binding(void) const;
-
-        /*!
-         * Returns the binding point for the \ref GlyphAtlas
-         * to access each value as a vec2 fp16 value. A value
-         * of -1 indicates that there is no special binding
-         * point for such access.
-         */
-        int
-        glyph_atlas_store_binding_fp16x2(void) const;
 
         /*!
          * Returns the binding point of the data store buffer

--- a/inc/fastuidraw/glsl/shader_source.hpp
+++ b/inc/fastuidraw/glsl/shader_source.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_SHADER_SOURCE_HPP
+#define FASTUIDRAW_SHADER_SOURCE_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -453,3 +454,5 @@ private:
 
 } //namespace glsl
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/glsl/shareable_value_list.hpp
+++ b/inc/fastuidraw/glsl/shareable_value_list.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_SHAREABLE_VALUE_LIST_HPP
+#define FASTUIDRAW_SHAREABLE_VALUE_LIST_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -145,3 +146,5 @@ namespace fastuidraw
 /*! @} */
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/symbol_list.hpp
+++ b/inc/fastuidraw/glsl/symbol_list.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_SYMBOL_LIST_HPP
+#define FASTUIDRAW_SYMBOL_LIST_HPP
 
 #include <fastuidraw/glsl/varying_list.hpp>
 #include <fastuidraw/glsl/shareable_value_list.hpp>
@@ -71,3 +72,5 @@ namespace fastuidraw
 /*! @} */
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/unpack_source_generator.hpp
+++ b/inc/fastuidraw/glsl/unpack_source_generator.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_UNPACK_SOURCE_GENERATOR_HPP
+#define FASTUIDRAW_UNPACK_SOURCE_GENERATOR_HPP
 
 #include <fastuidraw/glsl/shader_source.hpp>
 
@@ -293,3 +294,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/inc/fastuidraw/glsl/varying_list.hpp
+++ b/inc/fastuidraw/glsl/varying_list.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_VARYING_LIST_HPP
+#define FASTUIDRAW_VARYING_LIST_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -203,3 +204,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/inc/fastuidraw/image.hpp
+++ b/inc/fastuidraw/image.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_IMAGE_HPP
+#define FASTUIDRAW_IMAGE_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -343,3 +344,5 @@ class ImageAtlas;
 /*! @} */
 
 } //namespace
+
+#endif

--- a/inc/fastuidraw/image_atlas.hpp
+++ b/inc/fastuidraw/image_atlas.hpp
@@ -18,7 +18,8 @@
 
 
 
-#pragma once
+#ifndef FASTUIDRAW_IMAGE_ATLAS_HPP
+#define FASTUIDRAW_IMAGE_ATLAS_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -391,3 +392,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/arc_stroked_point.hpp
+++ b/inc/fastuidraw/painter/attribute_data/arc_stroked_point.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_ARC_STROKED_POINT_HPP
+#define FASTUIDRAW_ARC_STROKED_POINT_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -586,3 +587,5 @@ namespace ArcStrokedPointPacking
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/filled_path.hpp
+++ b/inc/fastuidraw/painter/attribute_data/filled_path.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_FILLED_PATH_HPP
+#define FASTUIDRAW_FILLED_PATH_HPP
 
 #include <fastuidraw/util/fastuidraw_memory.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -275,3 +276,5 @@ private:
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/glyph_attribute_packer.hpp
+++ b/inc/fastuidraw/painter/attribute_data/glyph_attribute_packer.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_ATTRIBUTE_PACKER_HPP
+#define FASTUIDRAW_GLYPH_ATTRIBUTE_PACKER_HPP
 
 #include <fastuidraw/text/glyph.hpp>
 
@@ -148,3 +149,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/glyph_run.hpp
+++ b/inc/fastuidraw/painter/attribute_data/glyph_run.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_RUN_HPP
+#define FASTUIDRAW_GLYPH_RUN_HPP
 
 #include <fastuidraw/util/matrix.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -220,3 +221,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/glyph_sequence.hpp
+++ b/inc/fastuidraw/painter/attribute_data/glyph_sequence.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_SEQUENCE_HPP
+#define FASTUIDRAW_GLYPH_SEQUENCE_HPP
 
 #include <fastuidraw/util/matrix.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -266,3 +267,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/painter_attribute.hpp
+++ b/inc/fastuidraw/painter/attribute_data/painter_attribute.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ATTRIBUTE_HPP
+#define FASTUIDRAW_PAINTER_ATTRIBUTE_HPP
 
 
 #include <fastuidraw/util/vecN.hpp>
@@ -67,3 +68,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/painter_attribute_data.hpp
+++ b/inc/fastuidraw/painter/attribute_data/painter_attribute_data.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ATTRIBUTE_DATA_HPP
+#define FASTUIDRAW_PAINTER_ATTRIBUTE_DATA_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/painter/attribute_data/painter_attribute.hpp>
@@ -153,3 +154,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/painter_attribute_data_filler.hpp
+++ b/inc/fastuidraw/painter/attribute_data/painter_attribute_data_filler.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ATTRIBUTE_DATA_FILLER_HPP
+#define FASTUIDRAW_PAINTER_ATTRIBUTE_DATA_FILLER_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -93,3 +94,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/painter_attribute_writer.hpp
+++ b/inc/fastuidraw/painter/attribute_data/painter_attribute_writer.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ATTRIBUTE_WRITER_HPP
+#define FASTUIDRAW_PAINTER_ATTRIBUTE_WRITER_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -177,3 +178,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/stroked_path.hpp
+++ b/inc/fastuidraw/painter/attribute_data/stroked_path.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_STROKED_PATH_HPP
+#define FASTUIDRAW_STROKED_PATH_HPP
 
 #include <fastuidraw/util/fastuidraw_memory.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -431,3 +432,5 @@ private:
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/stroked_point.hpp
+++ b/inc/fastuidraw/painter/attribute_data/stroked_point.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_STROKED_POINT_HPP
+#define FASTUIDRAW_STROKED_POINT_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -924,3 +925,5 @@ namespace StrokedPointPacking
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/attribute_data/stroking_attribute_writer.hpp
+++ b/inc/fastuidraw/painter/attribute_data/stroking_attribute_writer.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_STROKING_ATTRIBUTE_WRITER_HPP
+#define FASTUIDRAW_STROKING_ATTRIBUTE_WRITER_HPP
 
 #include <fastuidraw/path_effect.hpp>
 #include <fastuidraw/painter/painter_enums.hpp>
@@ -121,3 +122,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_backend.hpp
+++ b/inc/fastuidraw/painter/backend/painter_backend.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BACKEND_HPP
+#define FASTUIDRAW_PAINTER_BACKEND_HPP
 
 #include <fastuidraw/util/blend_mode.hpp>
 #include <fastuidraw/util/rect.hpp>
@@ -167,3 +168,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_brush_adjust.hpp
+++ b/inc/fastuidraw/painter/backend/painter_brush_adjust.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BRUSH_ADJUST_HPP
+#define FASTUIDRAW_PAINTER_BRUSH_ADJUST_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -98,3 +99,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_clip_equations.hpp
+++ b/inc/fastuidraw/painter/backend/painter_clip_equations.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_CLIP_EQUATIONS_HPP
+#define FASTUIDRAW_PAINTER_CLIP_EQUATIONS_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -105,3 +106,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_draw.hpp
+++ b/inc/fastuidraw/painter/backend/painter_draw.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_DRAW_HPP
+#define FASTUIDRAW_PAINTER_DRAW_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -239,3 +240,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_draw_break_action.hpp
+++ b/inc/fastuidraw/painter/backend/painter_draw_break_action.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_DRAW_BREAK_ACTION_HPP
+#define FASTUIDRAW_PAINTER_DRAW_BREAK_ACTION_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/gpu_dirty_state.hpp>
@@ -56,3 +57,5 @@ class PainterBackend;
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_engine.hpp
+++ b/inc/fastuidraw/painter/backend/painter_engine.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ENGINE_HPP
+#define FASTUIDRAW_PAINTER_ENGINE_HPP
 
 #include <fastuidraw/util/blend_mode.hpp>
 #include <fastuidraw/util/rect.hpp>
@@ -335,3 +336,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_header.hpp
+++ b/inc/fastuidraw/painter/backend/painter_header.hpp
@@ -15,7 +15,8 @@
  * \author Kevin Rogovin <kevin.rogovin@gmail.com>
  *
  */
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_HEADER_HPP
+#define FASTUIDRAW_PAINTER_HEADER_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -213,3 +214,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_item_matrix.hpp
+++ b/inc/fastuidraw/painter/backend/painter_item_matrix.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ITEM_MATRIX_HPP
+#define FASTUIDRAW_PAINTER_ITEM_MATRIX_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -128,3 +129,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_shader_group.hpp
+++ b/inc/fastuidraw/painter/backend/painter_shader_group.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_GROUP_HPP
+#define FASTUIDRAW_PAINTER_SHADER_GROUP_HPP
 
 #include <stdint.h>
 #include <fastuidraw/util/blend_mode.hpp>
@@ -82,3 +83,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_shader_registrar.hpp
+++ b/inc/fastuidraw/painter/backend/painter_shader_registrar.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_REGISTRAR_HPP
+#define FASTUIDRAW_PAINTER_SHADER_REGISTRAR_HPP
 
 #include <fastuidraw/painter/shader/painter_shader_set.hpp>
 #include <fastuidraw/util/mutex.hpp>
@@ -300,3 +301,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/backend/painter_surface.hpp
+++ b/inc/fastuidraw/painter/backend/painter_surface.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SURFACE_HPP
+#define FASTUIDRAW_PAINTER_SURFACE_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/reference_counted.hpp>
@@ -336,3 +337,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/painter/effects/painter_effect.hpp
+++ b/inc/fastuidraw/painter/effects/painter_effect.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_EFFECT_HPP
+#define FASTUIDRAW_PAINTER_EFFECT_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -107,3 +108,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/effects/painter_effect_brush.hpp
+++ b/inc/fastuidraw/painter/effects/painter_effect_brush.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_EFFECT_BRUSH_HPP
+#define FASTUIDRAW_PAINTER_EFFECT_BRUSH_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/painter/effects/painter_effect.hpp>
@@ -354,3 +355,5 @@ namespace fastuidraw
 
 /*! @} */
 };
+
+#endif

--- a/inc/fastuidraw/painter/fill_rule.hpp
+++ b/inc/fastuidraw/painter/fill_rule.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_FILL_RULE_HPP
+#define FASTUIDRAW_FILL_RULE_HPP
 
 #include <fastuidraw/painter/painter_enums.hpp>
 
@@ -96,3 +97,5 @@ namespace fastuidraw
   };
   /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/painter.hpp
+++ b/inc/fastuidraw/painter/painter.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_HPP
+#define FASTUIDRAW_PAINTER_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -1765,3 +1766,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/painter_brush.hpp
+++ b/inc/fastuidraw/painter/painter_brush.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BRUSH_HPP
+#define FASTUIDRAW_PAINTER_BRUSH_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -900,3 +901,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/painter_custom_brush.hpp
+++ b/inc/fastuidraw/painter/painter_custom_brush.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_CUSTOM_BRUSH_HPP
+#define FASTUIDRAW_PAINTER_CUSTOM_BRUSH_HPP
 
 #include <fastuidraw/painter/shader_data/painter_data_value.hpp>
 #include <fastuidraw/painter/shader_data/painter_brush_shader_data.hpp>
@@ -72,3 +73,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/painter_enums.hpp
+++ b/inc/fastuidraw/painter/painter_enums.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ENUMS_HPP
+#define FASTUIDRAW_PAINTER_ENUMS_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -925,3 +926,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_blend_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_blend_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BLEND_SHADER_HPP
+#define FASTUIDRAW_PAINTER_BLEND_SHADER_HPP
 #include <fastuidraw/painter/shader/painter_shader.hpp>
 
 namespace fastuidraw
@@ -108,3 +109,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_blend_shader_set.hpp
+++ b/inc/fastuidraw/painter/shader/painter_blend_shader_set.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BLEND_SHADER_SET_HPP
+#define FASTUIDRAW_PAINTER_BLEND_SHADER_SET_HPP
 
 #include <fastuidraw/util/blend_mode.hpp>
 #include <fastuidraw/painter/painter_enums.hpp>
@@ -105,3 +106,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_brush_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_brush_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BRUSH_SHADER_HPP
+#define FASTUIDRAW_PAINTER_BRUSH_SHADER_HPP
 #include <fastuidraw/painter/shader/painter_shader.hpp>
 
 namespace fastuidraw
@@ -62,3 +63,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_brush_shader_set.hpp
+++ b/inc/fastuidraw/painter/shader/painter_brush_shader_set.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BRUSH_SHADER_SET_HPP
+#define FASTUIDRAW_PAINTER_BRUSH_SHADER_SET_HPP
 
 #include <fastuidraw/painter/shader/painter_brush_shader.hpp>
 #include <fastuidraw/painter/shader/painter_image_brush_shader.hpp>
@@ -109,3 +110,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_dashed_stroke_shader_set.hpp
+++ b/inc/fastuidraw/painter/shader/painter_dashed_stroke_shader_set.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_DASHED_STROKE_SHADER_SET_HPP
+#define FASTUIDRAW_PAINTER_DASHED_STROKE_SHADER_SET_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/matrix.hpp>
@@ -91,3 +92,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_fill_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_fill_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_FILL_SHADER_HPP
+#define FASTUIDRAW_PAINTER_FILL_SHADER_HPP
 
 #include <fastuidraw/painter/painter_enums.hpp>
 #include <fastuidraw/painter/shader/painter_item_shader.hpp>
@@ -106,3 +107,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_glyph_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_glyph_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_GLYPH_SHADER_HPP
+#define FASTUIDRAW_PAINTER_GLYPH_SHADER_HPP
 
 #include <fastuidraw/text/glyph.hpp>
 #include <fastuidraw/painter/shader/painter_item_shader.hpp>
@@ -93,3 +94,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_gradient_brush_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_gradient_brush_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_GRADIENT_BRUSH_SHADER_HPP
+#define FASTUIDRAW_PAINTER_GRADIENT_BRUSH_SHADER_HPP
 
 #include <fastuidraw/painter/shader_data/painter_gradient_brush_shader_data.hpp>
 #include <fastuidraw/painter/painter_custom_brush.hpp>
@@ -201,3 +202,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_image_brush_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_image_brush_shader.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_IMAGE_BRUSH_SHADER_HPP
+#define FASTUIDRAW_PAINTER_IMAGE_BRUSH_SHADER_HPP
 
 #include <fastuidraw/painter/painter_custom_brush.hpp>
 #include <fastuidraw/painter/shader_data/painter_image_brush_shader_data.hpp>
@@ -221,3 +222,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_item_coverage_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_item_coverage_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ITEM_COVERAGE_SHADER_HPP
+#define FASTUIDRAW_PAINTER_ITEM_COVERAGE_SHADER_HPP
 #include <fastuidraw/painter/shader/painter_shader.hpp>
 
 namespace fastuidraw
@@ -70,3 +71,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_item_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_item_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_ITEM_SHADER_HPP
+#define FASTUIDRAW_PAINTER_ITEM_SHADER_HPP
 #include <fastuidraw/painter/shader/painter_shader.hpp>
 #include <fastuidraw/painter/shader/painter_item_coverage_shader.hpp>
 
@@ -114,3 +115,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_HPP
+#define FASTUIDRAW_PAINTER_SHADER_HPP
 #include <fastuidraw/util/reference_counted.hpp>
 
 namespace fastuidraw
@@ -180,3 +181,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_shader_set.hpp
+++ b/inc/fastuidraw/painter/shader/painter_shader_set.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_SET_HPP
+#define FASTUIDRAW_PAINTER_SHADER_SET_HPP
 
 #include <fastuidraw/painter/painter_enums.hpp>
 #include <fastuidraw/painter/shader/painter_brush_shader.hpp>
@@ -163,3 +164,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader/painter_stroke_shader.hpp
+++ b/inc/fastuidraw/painter/shader/painter_stroke_shader.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_STROKE_SHADER_HPP
+#define FASTUIDRAW_PAINTER_STROKE_SHADER_HPP
 
 #include <fastuidraw/path_enums.hpp>
 #include <fastuidraw/painter/painter_enums.hpp>
@@ -231,3 +232,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_brush_shader_data.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_brush_shader_data.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BRUSH_SHADER_DATA_HPP
+#define FASTUIDRAW_PAINTER_BRUSH_SHADER_DATA_HPP
 
 #include <fastuidraw/util/c_array.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -104,3 +105,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_dashed_stroke_params.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_dashed_stroke_params.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_DASHED_STROKE_PARAMS_HPP
+#define FASTUIDRAW_PAINTER_DASHED_STROKE_PARAMS_HPP
 
 #include <fastuidraw/painter/shader_data/painter_stroke_params.hpp>
 #include <fastuidraw/painter/shader_data/painter_shader_data.hpp>
@@ -229,3 +230,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_data.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_data.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_DATA_HPP
+#define FASTUIDRAW_PAINTER_DATA_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/painter/shader_data/painter_data_value.hpp>
@@ -321,3 +322,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_data_value.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_data_value.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_DATA_VALUE_HPP
+#define FASTUIDRAW_PAINTER_DATA_VALUE_HPP
 
 #include <fastuidraw/painter/shader_data/painter_packed_value.hpp>
 
@@ -109,3 +110,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_gradient_brush_shader_data.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_gradient_brush_shader_data.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_GRADIENT_BRUSH_SHADER_DATA_HPP
+#define FASTUIDRAW_PAINTER_GRADIENT_BRUSH_SHADER_DATA_HPP
 
 #include <fastuidraw/colorstop_atlas.hpp>
 #include <fastuidraw/painter/painter_enums.hpp>
@@ -384,3 +385,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_image_brush_shader_data.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_image_brush_shader_data.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_IMAGE_BRUSH_SHADER_DATA_HPP
+#define FASTUIDRAW_PAINTER_IMAGE_BRUSH_SHADER_DATA_HPP
 
 #include <fastuidraw/image.hpp>
 #include <fastuidraw/painter/painter_enums.hpp>
@@ -214,3 +215,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_packed_value.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_packed_value.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_PACKED_VALUE_HPP
+#define FASTUIDRAW_PAINTER_PACKED_VALUE_HPP
 
 
 #include <fastuidraw/util/util.hpp>
@@ -204,3 +205,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_packed_value_pool.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_packed_value_pool.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_PACKED_VALUE_POOL_HPP
+#define FASTUIDRAW_PAINTER_PACKED_VALUE_POOL_HPP
 
 #include <fastuidraw/painter/shader_data/painter_data.hpp>
 
@@ -117,3 +118,5 @@ namespace fastuidraw
   }
 
 } //namespace
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_shader_data.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_shader_data.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_DATA_HPP
+#define FASTUIDRAW_PAINTER_SHADER_DATA_HPP
 
 #include <fastuidraw/util/c_array.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -104,3 +105,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/painter/shader_data/painter_stroke_params.hpp
+++ b/inc/fastuidraw/painter/shader_data/painter_stroke_params.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_STROKE_PARAMS_HPP
+#define FASTUIDRAW_PAINTER_STROKE_PARAMS_HPP
 
 #include <fastuidraw/painter/shader_data/painter_shader_data.hpp>
 #include <fastuidraw/painter/shader/painter_stroke_shader.hpp>
@@ -177,3 +178,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/painter/shader_filled_path.hpp
+++ b/inc/fastuidraw/painter/shader_filled_path.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_SHADER_FILLED_PATH_HPP
+#define FASTUIDRAW_SHADER_FILLED_PATH_HPP
 
 #include <fastuidraw/util/fastuidraw_memory.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -146,3 +147,5 @@ private:
 /*! @} */
 
 } //namespace f
+
+#endif

--- a/inc/fastuidraw/painter/stroking_style.hpp
+++ b/inc/fastuidraw/painter/stroking_style.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_STROKING_STYLE_HPP
+#define FASTUIDRAW_STROKING_STYLE_HPP
 
 #include <fastuidraw/painter/painter_enums.hpp>
 
@@ -75,3 +76,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/partitioned_tessellated_path.hpp
+++ b/inc/fastuidraw/partitioned_tessellated_path.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PARTITIONED_TESSELLATED_PATH_HPP
+#define FASTUIDRAW_PARTITIONED_TESSELLATED_PATH_HPP
 
 #include <fastuidraw/util/matrix.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -319,3 +320,5 @@ namespace fastuidraw  {
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/path.hpp
+++ b/inc/fastuidraw/path.hpp
@@ -18,7 +18,8 @@
 
 
 
-#pragma once
+#ifndef FASTUIDRAW_PATH_HPP
+#define FASTUIDRAW_PATH_HPP
 
 #include <fastuidraw/util/fastuidraw_memory.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -1100,3 +1101,5 @@ private:
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/path_dash_effect.hpp
+++ b/inc/fastuidraw/path_dash_effect.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PATH_DASH_EFFECT_HPP
+#define FASTUIDRAW_PATH_DASH_EFFECT_HPP
 
 #include <fastuidraw/path_effect.hpp>
 
@@ -94,3 +95,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/path_effect.hpp
+++ b/inc/fastuidraw/path_effect.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PATH_EFFECT_HPP
+#define FASTUIDRAW_PATH_EFFECT_HPP
 
 #include <fastuidraw/tessellated_path.hpp>
 
@@ -248,3 +249,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/path_enums.hpp
+++ b/inc/fastuidraw/path_enums.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PATH_ENUMS_HPP
+#define FASTUIDRAW_PATH_ENUMS_HPP
 
 namespace fastuidraw  {
 
@@ -98,3 +99,5 @@ public:
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/tessellated_path.hpp
+++ b/inc/fastuidraw/tessellated_path.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_TESSELLATED_PATH_HPP
+#define FASTUIDRAW_TESSELLATED_PATH_HPP
 
 
 #include <fastuidraw/util/fastuidraw_memory.hpp>
@@ -952,3 +953,5 @@ private:
 /*! @} */
 
 }
+
+#endif

--- a/inc/fastuidraw/text/character_encoding.hpp
+++ b/inc/fastuidraw/text/character_encoding.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_CHARACTER_ENCODING_HPP
+#define FASTUIDRAW_CHARACTER_ENCODING_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -135,3 +136,5 @@ namespace fastuidraw
   }
 
 }
+
+#endif

--- a/inc/fastuidraw/text/font.hpp
+++ b/inc/fastuidraw/text/font.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_FONT_HPP
+#define FASTUIDRAW_FONT_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/c_array.hpp>
@@ -190,3 +191,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/font_database.hpp
+++ b/inc/fastuidraw/text/font_database.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_FONT_DATABASE_HPP
+#define FASTUIDRAW_FONT_DATABASE_HPP
 
 #include <fastuidraw/text/glyph_source.hpp>
 
@@ -418,3 +419,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/font_freetype.hpp
+++ b/inc/fastuidraw/text/font_freetype.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_FONT_FREETYPE_HPP
+#define FASTUIDRAW_FONT_FREETYPE_HPP
 
 #include <fastuidraw/text/font.hpp>
 #include <fastuidraw/text/freetype_lib.hpp>
@@ -159,3 +160,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/font_metrics.hpp
+++ b/inc/fastuidraw/text/font_metrics.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_FONT_METRICS_HPP
+#define FASTUIDRAW_FONT_METRICS_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -126,3 +127,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/font_properties.hpp
+++ b/inc/fastuidraw/text/font_properties.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_FONT_PROPERTIES_HPP
+#define FASTUIDRAW_FONT_PROPERTIES_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -186,3 +187,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/freetype_face.hpp
+++ b/inc/fastuidraw/text/freetype_face.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_FREETYPE_FACE_HPP
+#define FASTUIDRAW_FREETYPE_FACE_HPP
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -207,3 +208,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/freetype_lib.hpp
+++ b/inc/fastuidraw/text/freetype_lib.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_FREETYPE_LIB_HPP
+#define FASTUIDRAW_FREETYPE_LIB_HPP
 
 
 #include <ft2build.h>
@@ -86,3 +87,5 @@ namespace fastuidraw
   };
 /*! @} */
 };
+
+#endif

--- a/inc/fastuidraw/text/glyph.hpp
+++ b/inc/fastuidraw/text/glyph.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_HPP
+#define FASTUIDRAW_GLYPH_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -227,3 +228,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_atlas.hpp
+++ b/inc/fastuidraw/text/glyph_atlas.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_ATLAS_HPP
+#define FASTUIDRAW_GLYPH_ATLAS_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -190,3 +191,5 @@ namespace fastuidraw
   };
 /*! @} */
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/text/glyph_attribute.hpp
+++ b/inc/fastuidraw/text/glyph_attribute.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_ATTRIBUTE_HPP
+#define FASTUIDRAW_GLYPH_ATTRIBUTE_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -159,3 +160,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_cache.hpp
+++ b/inc/fastuidraw/text/glyph_cache.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_CACHE_HPP
+#define FASTUIDRAW_GLYPH_CACHE_HPP
 
 #include <fastuidraw/util/reference_counted.hpp>
 #include <fastuidraw/text/glyph_atlas.hpp>
@@ -257,3 +258,5 @@ namespace fastuidraw
   };
 /*! @} */
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/text/glyph_generate_params.hpp
+++ b/inc/fastuidraw/text/glyph_generate_params.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_GENERATE_PARAMS_HPP
+#define FASTUIDRAW_GLYPH_GENERATE_PARAMS_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -171,3 +172,5 @@ namespace fastuidraw
     banded_rays_average_number_curves_thresh(float v);
   }
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_metrics.hpp
+++ b/inc/fastuidraw/text/glyph_metrics.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_METRICS_HPP
+#define FASTUIDRAW_GLYPH_METRICS_HPP
 
 #include <stdint.h>
 
@@ -129,3 +130,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_metrics_value.hpp
+++ b/inc/fastuidraw/text/glyph_metrics_value.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_METRICS_VALUE_HPP
+#define FASTUIDRAW_GLYPH_METRICS_VALUE_HPP
 
 #include <stdint.h>
 
@@ -91,3 +92,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_render_data.hpp
+++ b/inc/fastuidraw/text/glyph_render_data.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_RENDER_DATA_HPP
+#define FASTUIDRAW_GLYPH_RENDER_DATA_HPP
 
 #include <stdint.h>
 
@@ -104,3 +105,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_render_data_banded_rays.hpp
+++ b/inc/fastuidraw/text/glyph_render_data_banded_rays.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_RENDER_DATA_BANDED_RAYS_HPP
+#define FASTUIDRAW_GLYPH_RENDER_DATA_BANDED_RAYS_HPP
 
 #include <fastuidraw/util/rect.hpp>
 #include <fastuidraw/text/glyph_render_data.hpp>
@@ -325,3 +326,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_render_data_restricted_rays.hpp
+++ b/inc/fastuidraw/text/glyph_render_data_restricted_rays.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_RENDER_DATA_RESTRICTED_RAYS_HPP
+#define FASTUIDRAW_GLYPH_RENDER_DATA_RESTRICTED_RAYS_HPP
 
 #include <fastuidraw/util/rect.hpp>
 #include <fastuidraw/text/glyph_render_data.hpp>
@@ -457,3 +458,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_render_data_texels.hpp
+++ b/inc/fastuidraw/text/glyph_render_data_texels.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_RENDER_DATA_TEXELS_HPP
+#define FASTUIDRAW_GLYPH_RENDER_DATA_TEXELS_HPP
 
 #include <fastuidraw/text/glyph_render_data.hpp>
 
@@ -108,3 +109,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_renderer.hpp
+++ b/inc/fastuidraw/text/glyph_renderer.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_RENDERER_HPP
+#define FASTUIDRAW_GLYPH_RENDERER_HPP
 
 namespace fastuidraw
 {
@@ -150,3 +151,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/text/glyph_source.hpp
+++ b/inc/fastuidraw/text/glyph_source.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_SOURCE_HPP
+#define FASTUIDRAW_GLYPH_SOURCE_HPP
 
 #include <fastuidraw/text/font.hpp>
 #include <fastuidraw/text/glyph.hpp>
@@ -86,3 +87,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/api_callback.hpp
+++ b/inc/fastuidraw/util/api_callback.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_API_CALLBACK_HPP
+#define FASTUIDRAW_API_CALLBACK_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/reference_counted.hpp>
@@ -214,3 +215,5 @@ namespace fastuidraw
     void *m_d;
   };
 }
+
+#endif

--- a/inc/fastuidraw/util/blend_mode.hpp
+++ b/inc/fastuidraw/util/blend_mode.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_BLEND_MODE_HPP
+#define FASTUIDRAW_BLEND_MODE_HPP
 
 #include <stdint.h>
 
@@ -516,3 +517,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/c_array.hpp
+++ b/inc/fastuidraw/util/c_array.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_C_ARRAY_HPP
+#define FASTUIDRAW_C_ARRAY_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -494,3 +495,5 @@ pack_as_fp16(float x, float y)
 /*! @} */
 
 } //namespace
+
+#endif

--- a/inc/fastuidraw/util/data_buffer.hpp
+++ b/inc/fastuidraw/util/data_buffer.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DATA_BUFFER_HPP
+#define FASTUIDRAW_DATA_BUFFER_HPP
 
 #include <fastuidraw/util/data_buffer_base.hpp>
 
@@ -110,3 +111,5 @@ namespace fastuidraw {
 
 /*! @} */
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/util/data_buffer_base.hpp
+++ b/inc/fastuidraw/util/data_buffer_base.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DATA_BUFFER_BASE_HPP
+#define FASTUIDRAW_DATA_BUFFER_BASE_HPP
 
 #include <stdint.h>
 #include <fastuidraw/util/reference_counted.hpp>
@@ -72,3 +73,5 @@ namespace fastuidraw
 
 /*! @} */
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/util/fastuidraw_memory.hpp
+++ b/inc/fastuidraw/util/fastuidraw_memory.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_FASTUIDRAW_MEMORY_HPP
+#define FASTUIDRAW_FASTUIDRAW_MEMORY_HPP
 
 /*!\addtogroup Utility
  * @{
@@ -93,3 +94,5 @@
   fastuidraw::memory::free_implement(ptr, __FILE__, __LINE__)
 
 /*! @} */
+
+#endif

--- a/inc/fastuidraw/util/fastuidraw_memory_private.hpp
+++ b/inc/fastuidraw/util/fastuidraw_memory_private.hpp
@@ -20,7 +20,8 @@
 /* Private functions needed for macros in fastuidraw_memory.hpp
  */
 
-#pragma once
+#ifndef FASTUIDRAW_FASTUIDRAW_MEMORY_PRIVATE_HPP
+#define FASTUIDRAW_FASTUIDRAW_MEMORY_PRIVATE_HPP
 
 #include <cstddef>
 
@@ -96,3 +97,5 @@ namespace memory
 } //namespace memory
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/util/gpu_dirty_state.hpp
+++ b/inc/fastuidraw/util/gpu_dirty_state.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GPU_DIRTY_STATE_HPP
+#define FASTUIDRAW_GPU_DIRTY_STATE_HPP
 
 #include <stdint.h>
 
@@ -158,3 +159,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/math.hpp
+++ b/inc/fastuidraw/util/math.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_MATH_HPP
+#define FASTUIDRAW_MATH_HPP
 
 #include <math.h>
 #include <stdlib.h>
@@ -278,3 +279,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/matrix.hpp
+++ b/inc/fastuidraw/util/matrix.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_MATRIX_HPP
+#define FASTUIDRAW_MATRIX_HPP
 
 #include <fastuidraw/util/math.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -818,3 +819,5 @@ typedef orthogonal_projection_params<float> float_orthogonal_projection_params;
 
 /*! @} */
 } //namespace
+
+#endif

--- a/inc/fastuidraw/util/mutex.hpp
+++ b/inc/fastuidraw/util/mutex.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_MUTEX_HPP
+#define FASTUIDRAW_MUTEX_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -93,3 +94,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/pixel_distance_math.hpp
+++ b/inc/fastuidraw/util/pixel_distance_math.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PIXEL_DISTANCE_MATH_HPP
+#define FASTUIDRAW_PIXEL_DISTANCE_MATH_HPP
 
 #include <fastuidraw/util/matrix.hpp>
 
@@ -45,3 +46,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/rect.hpp
+++ b/inc/fastuidraw/util/rect.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_RECT_HPP
+#define FASTUIDRAW_RECT_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/math.hpp>
@@ -339,3 +340,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/reference_count_atomic.hpp
+++ b/inc/fastuidraw/util/reference_count_atomic.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_REFERENCE_COUNT_ATOMIC_HPP
+#define FASTUIDRAW_REFERENCE_COUNT_ATOMIC_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -63,3 +64,5 @@ namespace fastuidraw
 
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/reference_count_non_concurrent.hpp
+++ b/inc/fastuidraw/util/reference_count_non_concurrent.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_REFERENCE_COUNT_NON_CONCURRENT_HPP
+#define FASTUIDRAW_REFERENCE_COUNT_NON_CONCURRENT_HPP
 
 #include <fastuidraw/util/util.hpp>
 
@@ -71,3 +72,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/reference_counted.hpp
+++ b/inc/fastuidraw/util/reference_counted.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_REFERENCE_COUNTED_HPP
+#define FASTUIDRAW_REFERENCE_COUNTED_HPP
 
 
 #include <fastuidraw/util/util.hpp>
@@ -514,3 +515,5 @@ namespace fastuidraw
 /*! @} */
 
 } //namespace fastuidraw
+
+#endif

--- a/inc/fastuidraw/util/rounded_rect.hpp
+++ b/inc/fastuidraw/util/rounded_rect.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_ROUNDED_RECT_HPP
+#define FASTUIDRAW_ROUNDED_RECT_HPP
 
 #include <fastuidraw/util/rect.hpp>
 
@@ -126,3 +127,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/static_resource.hpp
+++ b/inc/fastuidraw/util/static_resource.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_STATIC_RESOURCE_HPP
+#define FASTUIDRAW_STATIC_RESOURCE_HPP
 
 #include <fastuidraw/util/c_array.hpp>
 
@@ -75,3 +76,5 @@ namespace fastuidraw
   };
 /*! @} */
 }
+
+#endif

--- a/inc/fastuidraw/util/string_array.hpp
+++ b/inc/fastuidraw/util/string_array.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_STRING_ARRAY_HPP
+#define FASTUIDRAW_STRING_ARRAY_HPP
 
 #include <fastuidraw/util/c_array.hpp>
 #include <fastuidraw/util/util.hpp>
@@ -122,3 +123,5 @@ namespace fastuidraw
   };
 }
 /*! @} */
+
+#endif

--- a/inc/fastuidraw/util/util.hpp
+++ b/inc/fastuidraw/util/util.hpp
@@ -18,7 +18,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_UTIL_HPP
+#define FASTUIDRAW_UTIL_HPP
 
 #include <stdint.h>
 #include <stddef.h>
@@ -642,3 +643,5 @@ namespace fastuidraw
 
 }
 /*! @} */
+
+#endif

--- a/inc/fastuidraw/util/vecN.hpp
+++ b/inc/fastuidraw/util/vecN.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_VECN_HPP
+#define FASTUIDRAW_VECN_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/math.hpp>
@@ -1488,3 +1489,5 @@ pack_vec4(const vec4 &v)
 /*! @} */
 
 } //namespace
+
+#endif

--- a/make/Makefile.base.lib.mk
+++ b/make/Makefile.base.lib.mk
@@ -69,7 +69,7 @@ else
 
 libFastUIDraw_$(1): libFastUIDraw_$(1).so
 libFastUIDraw_$(1).so: $(FASTUIDRAW_STRING_RESOURCES_SRCS) $$(FASTUIDRAW_$(1)_ALL_OBJS)
-	$(CXX) -shared -Wl,-soname,libFastUIDraw_$(1).so -o libFastUIDraw_$(1).so $$(FASTUIDRAW_$(1)_ALL_OBJS) $(FASTUIDRAW_DEPS_LIBS)
+	$(CXX) -shared -Wl,$$(SONAME),libFastUIDraw_$(1).so -o libFastUIDraw_$(1).so $$(FASTUIDRAW_$(1)_ALL_OBJS) $(FASTUIDRAW_DEPS_LIBS)
 CLEAN_FILES += libFastUIDraw_$(1).so
 INSTALL_LIBS += libFastUIDraw_$(1).so
 .PHONY: libFastUIDraw_$(1) libFastUIDraw

--- a/make/Makefile.check.mk
+++ b/make/Makefile.check.mk
@@ -1,13 +1,12 @@
 ifeq ($(MAKECMDGOALS),check)
 
-
 ifeq (, $(shell which $(LEX)))
 CHECK_LEX := "Cannot find $(LEX) for lex/flex tool in path. Install package with tool, for example with Ubuntu using flex, apt install flex"
 else
 CHECK_LEX := "Found $(LEX) for lex/flex in path"
 endif
 
-CHECK_FREETYPE_CFLAGS_CODE := $(shell pkg-config freetype2 --cflags 1> /dev/null 2> /dev/null; echo $$?)
+CHECK_FREETYPE_CFLAGS_CODE := $(shell pkg-config freetype2 --cflags 1> /dev/null 2> /dev/null; $(ECHO) $$?)
 ifeq ($(CHECK_FREETYPE_CFLAGS_CODE), 0)
 CHECK_FREETYPE_CFLAGS := "Found cflags for freetype2: $(shell pkg-config freetype2 --cflags)"
 else
@@ -15,7 +14,7 @@ CHECK_FREETYPE_CFLAGS := "Cannot build FastUIDraw: Unable to find freetype2 cfla
 FASTUIDRAW_CAN_BUILD := 0
 endif
 
-CHECK_FREETYPE_LIBS_CODE := $(shell pkg-config freetype2 --libs 1> /dev/null 2> /dev/null; echo $$?)
+CHECK_FREETYPE_LIBS_CODE := $(shell pkg-config freetype2 --libs 1> /dev/null 2> /dev/null; $(ECHO) $$?)
 ifeq ($(CHECK_FREETYPE_LIBS_CODE), 0)
 CHECK_FREETYPE_LIBS := "Found libs for freetype2: $(shell pkg-config freetype2 --libs)"
 else
@@ -26,7 +25,7 @@ endif
 ## check for each of the GL headers
 define checkglheader
 $(eval FILE_$(1)_$(2):="$(GL_INCLUDEPATH)/$$(2)"
-EXISTS_$(1)_$(2):= $$(shell test -e $$(FILE_$(1)_$(2)) && echo -n yes)
+EXISTS_$(1)_$(2):= $$(shell test -e $$(FILE_$(1)_$(2)) && $(ECHO) -n yes)
 ifeq ($$(EXISTS_$(1)_$(2)),yes)
 FOUND_$(1)_HEADERS += $$(FILE_$(1)_$(2))
 HAVE_FOUND_$(1)_HEADERS := 1
@@ -71,14 +70,14 @@ endif
 
 ###################################################
 ## Check for demo requirements: SDL2_image and fontconfig
-CHECK_SDL_CFLAGS_CODE := $(shell pkg-config SDL2_image --cflags 1> /dev/null 2> /dev/null; echo $$?)
+CHECK_SDL_CFLAGS_CODE := $(shell pkg-config SDL2_image --cflags 1> /dev/null 2> /dev/null; $(ECHO) $$?)
 ifeq ($(CHECK_SDL_CFLAGS_CODE), 0)
 CHECK_SDL_CFLAGS := "Found cflags for SDL2_image: $(shell pkg-config SDL2_image --cflags)"
 else
 CHECK_SDL_CFLAGS := "Cannot build demos: Unable to find SDL2_image cflags from pkg-config SDL2_image: Install package with SDL2_image development files, for example on Ubuntu, apt install libsdl2-image-dev"
 endif
 
-CHECK_SDL_LIBS_CODE := $(shell pkg-config SDL2_image --libs 1> /dev/null 2> /dev/null; echo $$?)
+CHECK_SDL_LIBS_CODE := $(shell pkg-config SDL2_image --libs 1> /dev/null 2> /dev/null; $(ECHO) $$?)
 ifeq ($(CHECK_SDL_LIBS_CODE), 0)
 CHECK_SDL_LIBS := "Found libs for SDL2_image: $(shell pkg-config SDL2_image --libs)"
 else
@@ -86,14 +85,14 @@ CHECK_SDL_LIBS := "Cannot build demos: Unable to find SDL2_image libs from pkg-c
 endif
 
 ifeq ($(DEMOS_HAVE_FONT_CONFIG),1)
-CHECK_FONTCONFIG_CFLAGS_CODE := $(shell pkg-config fontconfig --cflags 1> /dev/null 2> /dev/null; echo $$?)
+CHECK_FONTCONFIG_CFLAGS_CODE := $(shell pkg-config fontconfig --cflags 1> /dev/null 2> /dev/null; $(ECHO) $$?)
 ifeq ($(CHECK_FONTCONFIG_CFLAGS_CODE), 0)
 CHECK_FONTCONFIG_CFLAGS := "Found cflags for fontconfig: $(shell pkg-config fontconfig --cflags)"
 else
 CHECK_FONTCONFIG_CFLAGS := "Cannot build demos: Unable to find fontconfig cflags from pkg-config: Install package with fontconfig development files, for example on Ubuntu, apt install libfontconfig1-dev"
 endif
 
-CHECK_FONTCONFIG_LIBS_CODE := $(shell pkg-config fontconfig --libs 1> /dev/null 2> /dev/null; echo $$?)
+CHECK_FONTCONFIG_LIBS_CODE := $(shell pkg-config fontconfig --libs 1> /dev/null 2> /dev/null; $(ECHO) $$?)
 ifeq ($(CHECK_FONTCONFIG_LIBS_CODE), 0)
 CHECK_FONTCONFIG_LIBS := "Found libs for fontconfig: $(shell pkg-config fontconfig --libs)"
 else
@@ -103,20 +102,20 @@ endif
 endif
 
 check:
-	@echo "$(CHECK_LEX)"
-	@echo "$(CHECK_SDL_CFLAGS)"
-	@echo "$(CHECK_SDL_LIBS)"
+	@$(ECHO) "$(CHECK_LEX)"
+	@$(ECHO) "$(CHECK_SDL_CFLAGS)"
+	@$(ECHO) "$(CHECK_SDL_LIBS)"
 ifeq ($(DEMOS_HAVE_FONT_CONFIG),1)
-	@echo "$(CHECK_FONTCONFIG_CFLAGS)"
-	@echo "$(CHECK_FONTCONFIG_LIBS)"
+	@$(ECHO) "$(CHECK_FONTCONFIG_CFLAGS)"
+	@$(ECHO) "$(CHECK_FONTCONFIG_LIBS)"
 endif
-	@echo "$(CHECK_FREETYPE_CFLAGS)"
-	@echo "$(CHECK_FREETYPE_LIBS)"
+	@$(ECHO) "$(CHECK_FREETYPE_CFLAGS)"
+	@$(ECHO) "$(CHECK_FREETYPE_LIBS)"
 ifeq ($(BUILD_GL), 1)
-	@echo "$(CHECK_GL_HEADERS)"
+	@$(ECHO) "$(CHECK_GL_HEADERS)"
 endif
 ifeq ($(BUILD_GLES), 1)
-	@echo "$(CHECK_GLES_HEADERS)"
+	@$(ECHO) "$(CHECK_GLES_HEADERS)"
 endif
 
 .PHONY: check

--- a/make/Makefile.docs.mk
+++ b/make/Makefile.docs.mk
@@ -34,7 +34,7 @@ glsl_processed_sources = $(patsubst %.glsl.resource_string, docs/doxy/glsl/%.gls
 docs/doxy/glsl/%.glsl.hpp: %.glsl.resource_string
 	@mkdir -p $(dir $@)
 	@sed 's/$(notdir $<)/$(notdir $@)/g' $< >> $@
-	@echo "Creating $@ from $<"
+	@$(ECHO) "Creating $@ from $<"
 
 docs: docs/doxy/html/index.html
 .PHONY: docs

--- a/make/Makefile.gl_backend.lib.mk
+++ b/make/Makefile.gl_backend.lib.mk
@@ -1,5 +1,5 @@
-FASTUIDRAW_GL_CFLAGS =
-FASTUIDRAW_GLES_CFLAGS = -DFASTUIDRAW_GL_USE_GLES
+FASTUIDRAW_GL_CFLAGS = -I$(GL_INCLUDEPATH)
+FASTUIDRAW_GLES_CFLAGS = -DFASTUIDRAW_GL_USE_GLES -I$(GL_INCLUDEPATH)
 
 FASTUIDRAW_GL_STRING_RESOURCES_SRCS = $(patsubst %.resource_string, build/string_resources_cpp/%.resource_string.cpp, $(FASTUIDRAW_GL_RESOURCE_STRING) )
 CLEAN_FILES += $(FASTUIDRAW_GL_STRING_RESOURCES_SRCS)
@@ -60,10 +60,10 @@ INSTALL_EXES += libFastUIDraw$(1)_$(2).dll libN$(1)_$(2).dll
 else
 libFastUIDraw$(1)_$(2): libFastUIDraw$(1)_$(2).so
 libFastUIDraw$(1)_$(2).so: libFastUIDraw_$(2).so libN$(1)_$(2).so $$(FASTUIDRAW_$(1)_$(2)_ALL_OBJS)
-	$(CXX) -shared -Wl,-soname,libFastUIDraw$(1)_$(2).so -o libFastUIDraw$(1)_$(2).so $$(FASTUIDRAW_$(1)_$(2)_ALL_OBJS) -L. -lN$(1)_$(2) -lFastUIDraw_$(2)
+	$(CXX) -shared -Wl,$$(SONAME),libFastUIDraw$(1)_$(2).so -o libFastUIDraw$(1)_$(2).so $$(FASTUIDRAW_$(1)_$(2)_ALL_OBJS) -L. -lN$(1)_$(2) -lFastUIDraw_$(2)
 libN$(1)_$(2): libN$(1)_$(2).so
 libN$(1)_$(2).so: $$(NGL_$(1)_$(2)_OBJ) libFastUIDraw_$(2)
-	$(CXX) -shared -Wl,-soname,libN$(1)_$(2).so -o libN$(1)_$(2).so $$(NGL_$(1)_$(2)_OBJ) -L. -lFastUIDraw_$(2)
+	$(CXX) -shared -Wl,$$(SONAME),libN$(1)_$(2).so -o libN$(1)_$(2).so $$(NGL_$(1)_$(2)_OBJ) -L. -lFastUIDraw_$(2)
 INSTALL_LIBS += libFastUIDraw$(1)_$(2).so libN$(1)_$(2).so
 endif
 

--- a/make/Makefile.gl_backend.settings.mk
+++ b/make/Makefile.gl_backend.settings.mk
@@ -11,7 +11,9 @@ ENVIRONMENTALDESCRIPTIONS += "BUILD_GLES: if set to 1 build GLES backend to Fast
 
 ###################################################
 ## Location in file system of GL (or GLES3) headers
-ifeq ($(MINGW_BUILD),0)
+ifeq ($(DARWIN_BUILD),1)
+  GL_DEFAULT_INCLUDEPATH = /usr/local/include
+else ifeq ($(MINGW_BUILD),0)
   GL_DEFAULT_INCLUDEPATH = /usr/include
 else ifeq ($(MINGW_MODE),MINGW64)
   GL_DEFAULT_INCLUDEPATH = /mingw64/include

--- a/make/Makefile.install.mk
+++ b/make/Makefile.install.mk
@@ -1,5 +1,5 @@
 
-INSTALL_LOCATION_VALUE=$(shell echo $(INSTALL_LOCATION))
+INSTALL_LOCATION_VALUE=$(shell $(ECHO) $(INSTALL_LOCATION))
 
 OTHER_API_GL = GLES
 OTHER_API_GLES = GL
@@ -7,21 +7,21 @@ OTHER_TYPE_release = debug
 OTHER_TYPE_debug = release
 
 fastuidraw-config.nodir: fastuidraw-config.in
-	@echo Generating $@
+	@$(ECHO) Generating $@
 	@cp $< $@
-	@sed -i 's!@FASTUIDRAW_DEPS_LIBS@!$(FASTUIDRAW_DEPS_LIBS)!g' $@
-	@sed -i 's!@FASTUIDRAW_DEPS_STATIC_LIBS@!$(FASTUIDRAW_DEPS_STATIC_LIBS)!g' $@
-	@sed -i 's!@FASTUIDRAW_release_CFLAGS@!$(FASTUIDRAW_release_CFLAGS)!g' $@
-	@sed -i 's!@FASTUIDRAW_debug_CFLAGS@!$(FASTUIDRAW_debug_CFLAGS)!g' $@
-	@sed -i 's!@FASTUIDRAW_GLES_CFLAGS@!$(FASTUIDRAW_GLES_CFLAGS)!g' $@
-	@sed -i 's!@FASTUIDRAW_GL_CFLAGS@!$(FASTUIDRAW_GL_CFLAGS)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_DEPS_LIBS@!$(FASTUIDRAW_DEPS_LIBS)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_DEPS_STATIC_LIBS@!$(FASTUIDRAW_DEPS_STATIC_LIBS)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_release_CFLAGS@!$(FASTUIDRAW_release_CFLAGS)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_debug_CFLAGS@!$(FASTUIDRAW_debug_CFLAGS)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_GLES_CFLAGS@!$(FASTUIDRAW_GLES_CFLAGS)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_GL_CFLAGS@!$(FASTUIDRAW_GL_CFLAGS)!g' $@
 	@chmod a+x $@
 CLEAN_FILES+=fastuidraw-config.nodir
 
 fastuidraw-config: fastuidraw-config.nodir
-	@echo Generating $@
+	@$(ECHO) Generating $@
 	@cp $< $@
-	@sed -i 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $@
+	@$(SED_INPLACE_REPLACE) 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $@
 	@chmod a+x $@
 # added to .PHONY to force regeneration so that if an environmental
 # variable (BUILD_GL, BUILD_GLES, INSTALL_LOCATION) changes, we can
@@ -38,24 +38,24 @@ TARGETLIST+=fastuidraw-config
 define pkgconfrulesapi
 $(eval ifeq ($(3),1)
 N$(2)-$(1).pc: n.pc.in fastuidraw-$(1).pc
-	@echo Generating $$@
+	@$(ECHO) Generating $$@
 	@cp $$< $$@
-	@sed -i 's!@TYPE@!$(1)!g' $$@
-	@sed -i 's!@API@!$(2)!g' $$@
-	@sed -i 's!@OTHER_API@!$$(OTHER_API_$(2))!g' $$@
-	@sed -i 's!@OTHER_TYPE@!$$(OTHER_TYPE_$(1))!g' $$@
-	@sed -i 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $$@
-	@sed -i 's!@N_ADDITIONAL_LIBS@!!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@TYPE@!$(1)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@API@!$(2)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@OTHER_API@!$$(OTHER_API_$(2))!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@OTHER_TYPE@!$$(OTHER_TYPE_$(1))!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@N_ADDITIONAL_LIBS@!!g' $$@
 
 fastuidraw$(2)-$(1).pc: fastuidraw-backend.pc.in N$(2)-$(1).pc
-	@echo Generating $$@
+	@$(ECHO) Generating $$@
 	@cp $$< $$@
-	@sed -i 's!@TYPE@!$(1)!g' $$@
-	@sed -i 's!@API@!$(2)!g' $$@
-	@sed -i 's!@OTHER_API@!$$(OTHER_API_$(2))!g' $$@
-	@sed -i 's!@OTHER_TYPE@!$$(OTHER_TYPE_$(1))!g' $$@
-	@sed -i 's!@FASTUIDRAW_BACKEND_CFLAGS@!$$(FASTUIDRAW_$(2)_CFLAGS)!g' $$@
-	@sed -i 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@TYPE@!$(1)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@API@!$(2)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@OTHER_API@!$$(OTHER_API_$(2))!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@OTHER_TYPE@!$$(OTHER_TYPE_$(1))!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_BACKEND_CFLAGS@!$$(FASTUIDRAW_$(2)_CFLAGS)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $$@
 
 .PHONY:fastuidraw$(2)-$(1).pc N$(2)-$(1).pc
 .SECONDARY: fastuidraw$(2)-$(1).pc N$(2)-$(1).pc
@@ -69,12 +69,12 @@ endef
 # $1: release or debug
 define pkgconfrules
 $(eval fastuidraw-$(1).pc: fastuidraw.pc.in
-	@echo Generating $$@
+	@$(ECHO) Generating $$@
 	@cp $$< $$@
-	@sed -i 's!@TYPE@!$(1)!g' $$@
-	@sed -i 's!@OTHER_TYPE@!$$(OTHER_TYPE_$(1))!g' $$@
-	@sed -i 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $$@
-	@sed -i 's!@FASTUIDRAW_CFLAGS@!$$(FASTUIDRAW_$(1)_BASE_CFLAGS)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@TYPE@!$(1)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@OTHER_TYPE@!$$(OTHER_TYPE_$(1))!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@INSTALL_LOCATION@!$(INSTALL_LOCATION_VALUE)!g' $$@
+	@$(SED_INPLACE_REPLACE) 's!@FASTUIDRAW_CFLAGS@!$$(FASTUIDRAW_$(1)_BASE_CFLAGS)!g' $$@
 .PHONY:fastuidraw-$(1).pc
 .SECONDARY: fastuidraw-$(1).pc
 CLEAN_FILES+=fastuidraw-$(1).pc

--- a/make/Makefile.settings.mk
+++ b/make/Makefile.settings.mk
@@ -1,21 +1,3 @@
-# detect MinGW: requires tweaks to various builds
-MINGW_BUILD = 0
-UNAME = $(shell uname -s)
-UNAMER= $(shell uname -r)
-ifeq ($(findstring MINGW,$(UNAME)),MINGW)
-  MINGW_BUILD = 1
-  ifeq ($(findstring 1.0, $(UNAMER)), 1.0)
-	MINGW_MODE = MINGW
-  else ifeq ($(findstring MINGW64,$(UNAME)),MINGW64)
-	MINGW_MODE = MINGW64
-  else ifeq ($(findstring MINGW32,$(UNAME)),MINGW32)
-	MINGW_MODE = MINGW32
-  endif
-endif
-
-#TODO: detection for DARWIN
-DARWIN_BUILD = 0
-
 ###########################################
 # Setting for building libFastUIDraw.so base library
 STRING_RESOURCE_CC = shell_scripts/fastuidraw-create-resource-cpp-file.sh
@@ -33,8 +15,20 @@ ifeq ($(MINGW_BUILD),1)
 fPIC =
 fHIDDEN =
 fHIDDEN_INLINES =
+else ifeq ($(DARWIN_BUILD),1)
+fPIC = -fPIC
+fHIDDEN =
+fHIDDEN_INLINES =
 else
 fPIC = -fPIC
 fHIDDEN_INLINES = -fvisibility-inlines-hidden
 fHIDDEN = -fvisibility=hidden
+endif
+
+ifeq ($(DARWIN_BUILD),0)
+SONAME = -soname
+SED_INPLACE_REPLACE=sed -i
+else
+SONAME = -install_name
+SED_INPLACE_REPLACE=sed -i ''
 endif

--- a/src/fastuidraw/gl_backend/ngl_generator/HeaderCreator.cpp
+++ b/src/fastuidraw/gl_backend/ngl_generator/HeaderCreator.cpp
@@ -744,13 +744,15 @@ openGL_function_info::
 HeaderEnd(ostream &headerFile, const list<string> &fileNames)
 {
   end_namespace(GlobalElements::get().m_namespace, headerFile);
+  headerFile << "\n#endif\n";
 }
 
 void
 openGL_function_info::
 HeaderStart(ostream &headerFile, const list<string> &fileNames)
 {
-  headerFile << "#pragma once\n\n";
+  headerFile << "#ifndef FASTUIDRAW_NGL_HPP\n\n"
+	     << "#include <KHR/khrplatform.h>\n";
   for(list<string>::const_iterator i=fileNames.begin(); i!=fileNames.end(); ++i)
     {
       headerFile  << "#include <" << *i << ">\n";

--- a/src/fastuidraw/gl_backend/painter_engine_gl.cpp
+++ b/src/fastuidraw/gl_backend/painter_engine_gl.cpp
@@ -854,7 +854,7 @@ adjust_for_context(const ContextProperties &ctx)
     }
 
   bool has_unpack;
-  #ifdef FASTUIDRAW_GL_USE_GLES
+  #ifndef FASTUIDRAW_GL_USE_GLES
     {
       has_unpack = ctx.version() >= ivec2(4, 2)
 	|| ctx.has_extension("GL_ARB_shading_language_packing");
@@ -872,7 +872,7 @@ adjust_for_context(const ContextProperties &ctx)
     {
       if (!has_unpack)
 	{
-	  /* Only happens in GLES 3.3, GLES 3.3 does not have unpack unpackHalf2x16()
+	  /* Only happens in GL 3.3, GL 3.3 does not have unpack unpackHalf2x16()
 	   * and does not have GL_ARB_texture_view either. However, it does always have
 	   * texture buffer support which allows an alias into the glyph-store.
 	   */

--- a/src/fastuidraw/glsl/shaders/Rules.mk
+++ b/src/fastuidraw/glsl/shaders/Rules.mk
@@ -22,7 +22,8 @@ FASTUIDRAW_RESOURCE_STRING += $(call filelist, \
 	fastuidraw_texture_fetch.glsl.resource_string \
 	fastuidraw_restricted_rays.glsl.resource_string \
 	fastuidraw_banded_rays.glsl.resource_string \
-	fastuidraw_compute_local_distance_from_pixel_distance.glsl.resource_string)
+	fastuidraw_compute_local_distance_from_pixel_distance.glsl.resource_string \
+	fastuidraw_unpackHalf2x16.glsl.resource_string)
 
 # Begin standard footer
 d		:= $(dirstack_$(sp))

--- a/src/fastuidraw/glsl/shaders/fastuidraw_atlases.glsl.resource_string
+++ b/src/fastuidraw/glsl/shaders/fastuidraw_atlases.glsl.resource_string
@@ -109,7 +109,7 @@
     uint fastuidraw_glyphDataStore_data[];
   };
   #define fastuidraw_fetch_glyph_data(X) (fastuidraw_glyphDataStore_data[int(X)])
-  #define fastuidraw_fetch_glyph_data_fp16x2(X) unpackHalf2x16(fastuidraw_glyphDataStore_data[int(X)])
+  #define fastuidraw_fetch_glyph_data_fp16x2(X) fastuidraw_unpackHalf2x16(fastuidraw_glyphDataStore_data[int(X)])
 
 #elif defined(FASTUIDRAW_GLYPH_DATA_STORE_TEXTURE_ARRAY)
 
@@ -125,23 +125,15 @@
   #define FASTUIDRAW_GLYPH_DATA_Y(T) FASTUIDRAW_EXTRACT_BITS(FASTUIDRAW_GLYPH_DATA_WIDTH_LOG2, FASTUIDRAW_GLYPH_DATA_HEIGHT_LOG2, T)
   #define FASTUIDRAW_GLYPH_DATA_X(T) FASTUIDRAW_EXTRACT_BITS(0, FASTUIDRAW_GLYPH_DATA_WIDTH_LOG2, T)
   #define FASTUIDRAW_GLYPH_DATA_COORD(v) ivec3(FASTUIDRAW_GLYPH_DATA_X(v), FASTUIDRAW_GLYPH_DATA_Y(v), FASTUIDRAW_GLYPH_DATA_LAYER(v))
-  #define fastuidraw_fetch_glyph_data(X) (texelFetch(fastuidraw_glyphDataStore, FASTUIDRAW_GLYPH_DATA_COORD(X), 0).r)
 
-  #ifdef FASTUIDRAW_GLYPH_ATLAS_USE_UNPACK
-    #define fastuidraw_fetch_glyph_data_fp16x2(X) unpackHalf2x16(fastuidraw_fetch_glyph_data(X))
-  #else
-    #define fastuidraw_fetch_glyph_data_fp16x2(X) (texelFetch(fastuidraw_glyphDataStore_fp16x2, FASTUIDRAW_GLYPH_DATA_COORD(X), 0).rg)
-  #endif
+  #define fastuidraw_fetch_glyph_data(X) (texelFetch(fastuidraw_glyphDataStore, FASTUIDRAW_GLYPH_DATA_COORD(X), 0).r)
+  #define fastuidraw_fetch_glyph_data_fp16x2(X) fastuidraw_unpackHalf2x16(fastuidraw_fetch_glyph_data(X))
 #else
 
   FASTUIDRAW_LAYOUT_BINDING(FASTUIDRAW_GLYPH_DATA_STORE_BINDING) uniform usamplerBuffer fastuidraw_glyphDataStore;
-  FASTUIDRAW_LAYOUT_BINDING(FASTUIDRAW_GLYPH_DATA_STORE_FP16X2_BINDING) uniform samplerBuffer fastuidraw_glyphDataStore_fp16x2;
+
   #define fastuidraw_fetch_glyph_data(X) (texelFetch(fastuidraw_glyphDataStore, int(X)).r)
-  #ifdef FASTUIDRAW_GLYPH_ATLAS_USE_UNPACK
-    #define fastuidraw_fetch_glyph_data_fp16x2(X) unpackHalf2x16(fastuidraw_fetch_glyph_data(X))
-  #else
-    #define fastuidraw_fetch_glyph_data_fp16x2(X) (texelFetch(fastuidraw_glyphDataStore_fp16x2, int(X)).rg)
-  #endif
+  #define fastuidraw_fetch_glyph_data_fp16x2(X) fastuidraw_unpackHalf2x16(fastuidraw_fetch_glyph_data(X))
 
 #endif
 ////////////////////////////////////////////////////

--- a/src/fastuidraw/glsl/shaders/fastuidraw_banded_rays.glsl.resource_string
+++ b/src/fastuidraw/glsl/shaders/fastuidraw_banded_rays.glsl.resource_string
@@ -67,17 +67,7 @@ fastuidraw_banded_rays_load_band(in uint loc, out fastuidraw_banded_rays_band ba
 vec2
 fastuidraw_banded_rays_load_point(in uint loc)
 {
-  #if !defined(fastuidraw_fetch_glyph_data_fp16x2)
-    {
-      uint raw;
-      raw = fastuidraw_fetch_glyph_data(loc);
-      return unpackHalf2x16(raw);
-    }
-  #else
-    {
-      return fastuidraw_fetch_glyph_data_fp16x2(loc);
-    }
-  #endif
+  return fastuidraw_fetch_glyph_data_fp16x2(loc);
 }
 
 void

--- a/src/fastuidraw/glsl/shaders/fastuidraw_restricted_rays.glsl.resource_string
+++ b/src/fastuidraw/glsl/shaders/fastuidraw_restricted_rays.glsl.resource_string
@@ -193,18 +193,7 @@ fastuidaw_restricted_rays_compute_box(in vec2 p,
 vec2
 fastuidraw_restricted_rays_unpack_point(in uint ptr)
 {
-  #if !defined(fastuidraw_fetch_glyph_data_fp16x2)
-    {
-      uint pt_packed;
-
-      pt_packed = fastuidraw_fetch_glyph_data(ptr);
-      return unpackHalf2x16(pt_packed);
-    }
-  #else
-    {
-      return fastuidraw_fetch_glyph_data_fp16x2(ptr);
-    }
-  #endif
+  return fastuidraw_fetch_glyph_data_fp16x2(ptr);
 }
 
 void

--- a/src/fastuidraw/glsl/shaders/fastuidraw_unpackHalf2x16.glsl.resource_string
+++ b/src/fastuidraw/glsl/shaders/fastuidraw_unpackHalf2x16.glsl.resource_string
@@ -1,0 +1,39 @@
+float
+fastuidraw_fp16_from_fp32(uint u)
+{
+  uint sign = (u & 0x8000u) << 16u;
+  uint exponent = (u & 0x7C00u) >> 10u;
+  uint mantissa = u & 0x03FFu;
+
+  if (exponent == 31u)
+    {
+      return uintBitsToFloat(sign | 0x7F800000u | mantissa);
+    }
+
+  // rely on bit-magic to get to fp32
+
+  //bias exponent from fp16 to fp32
+  exponent += (127u - 15u);
+
+  // shift exponent to fp32
+  exponent = exponent << 23u;
+
+  //shift matissa from fp16's 10-bits to fp32's 23-bits
+  mantissa = mantissa << 13u;
+
+  return uintBitsToFloat(sign | exponent | mantissa);  
+}
+
+
+#ifdef FASTUIDRAW_GL_HAS_UNPACKFP16
+#define fastuidraw_unpackHalf2x16(u) unpackHalf2x16(u)
+#else
+vec2
+fastuidraw_unpackHalf2x16(uint u)
+{
+  uint y = (u >> 16u);
+  uint x = (u & 0xFFFFu);
+  return vec2(fastuidraw_fp16_from_fp32(x),
+	      fastuidraw_fp16_from_fp32(y));
+}
+#endif

--- a/src/fastuidraw/glsl/shaders/painter/brush/fastuidraw_painter_brush.vert.glsl.resource_string
+++ b/src/fastuidraw/glsl/shaders/painter/brush/fastuidraw_painter_brush.vert.glsl.resource_string
@@ -28,8 +28,8 @@ fastuidraw_gl_vert_brush_main(in uint sub_shader, inout uint shader_data_block, 
   shader_data_block += FASTUIDRAW_LOCAL(fastuidraw_read_brush_header_size)();
 
   /* unpack the colr values and multiply by alpha */
-  color_rg = unpackHalf2x16(header.red_green);
-  color_ba = unpackHalf2x16(header.blue_alpha);
+  color_rg = fastuidraw_unpackHalf2x16(header.red_green);
+  color_ba = fastuidraw_unpackHalf2x16(header.blue_alpha);
   fastuidraw_brush_color_x = color_rg.x * color_ba.y;
   fastuidraw_brush_color_y = color_rg.y * color_ba.y;
   fastuidraw_brush_color_z = color_ba.x * color_ba.y;

--- a/src/fastuidraw/internal/3rd_party/glu-tess/glu-tess.hpp
+++ b/src/fastuidraw/internal/3rd_party/glu-tess/glu-tess.hpp
@@ -47,7 +47,8 @@
  * Silicon Graphics, Inc.
  */
 
-#pragma once
+#ifndef FASTUIDRAW_GLU_TESS_HPP
+#define FASTUIDRAW_GLU_TESS_HPP
 
 #include <climits>
 
@@ -312,3 +313,5 @@ FASTUIDRAW_GLU_TESS_TYPE_SAFE_CALL_BACK(FASTUIDRAW_GLU_TESS_WINDING_CALLBACK_DAT
 FASTUIDRAW_GLU_TESS_TYPE_SAFE_CALL_BACK(FASTUIDRAW_GLU_TESS_EMIT_MONOTONE_DATA, fastuidraw_glu_tess_function_emit_monotone_data, EmitMonotone);
 FASTUIDRAW_GLU_TESS_TYPE_SAFE_CALL_BACK(FASTUIDRAW_GLU_TESS_BOUNDARY_CORNER_DATA, fastuidraw_glu_tess_function_boundary_corner_point_data, BoundaryCornerPoint);
 FASTUIDRAW_GLU_TESS_TYPE_SAFE_CALL_BACK(FASTUIDRAW_GLU_TESS_EMIT_BOUNDARY_DATA, fastuidraw_glu_tess_function_emit_boundary_data, EmitBoundary);
+
+#endif

--- a/src/fastuidraw/internal/3rd_party/ieeehalfprecision/ieeehalfprecision.hpp
+++ b/src/fastuidraw/internal/3rd_party/ieeehalfprecision/ieeehalfprecision.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef FASTUIDRAW_IEEEHALFPRECISION_HPP
+#define FASTUIDRAW_IEEEHALFPRECISION_HPP
 
 #include <stdint.h>
 
@@ -7,3 +8,5 @@ namespace ieeehalfprecision
   void singles2halfp(uint16_t *target, const uint32_t *source, int numel);
   void halfp2singles(uint32_t *target, const uint16_t *source, int numel);
 }
+
+#endif

--- a/src/fastuidraw/internal/private/array2d.hpp
+++ b/src/fastuidraw/internal/private/array2d.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_ARRAY2D_HPP
+#define FASTUIDRAW_ARRAY2D_HPP
 
 #include <algorithm>
 #include <vector>
@@ -118,3 +119,5 @@ public:
 } //namespace
 
 /*! @} */
+
+#endif

--- a/src/fastuidraw/internal/private/array3d.hpp
+++ b/src/fastuidraw/internal/private/array3d.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_ARRAY3D_HPP
+#define FASTUIDRAW_ARRAY3D_HPP
 
 #include <algorithm>
 #include <vector>
@@ -124,3 +125,5 @@ public:
 } //namespace
 
 /*! @} */
+
+#endif

--- a/src/fastuidraw/internal/private/bezier_util.hpp
+++ b/src/fastuidraw/internal/private/bezier_util.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_BEZIER_UTIL_HPP
+#define FASTUIDRAW_BEZIER_UTIL_HPP
 
 #include <cmath>
 #include <fastuidraw/util/util.hpp>
@@ -298,3 +299,5 @@ namespace fastuidraw
 
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/bounding_box.hpp
+++ b/src/fastuidraw/internal/private/bounding_box.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_BOUNDING_BOX_HPP
+#define FASTUIDRAW_BOUNDING_BOX_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/util/rect.hpp>
@@ -302,3 +303,5 @@ namespace fastuidraw
     bool m_empty;
   };
 }
+
+#endif

--- a/src/fastuidraw/internal/private/clip.hpp
+++ b/src/fastuidraw/internal/private/clip.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_CLIP_HPP
+#define FASTUIDRAW_CLIP_HPP
 
 #include <vector>
 #include <fastuidraw/util/vecN.hpp>
@@ -108,3 +109,5 @@ namespace fastuidraw
     }
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/binding_points.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/binding_points.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_BINDING_POINTS_HPP
+#define FASTUIDRAW_BINDING_POINTS_HPP
 
 namespace fastuidraw { namespace gl { namespace detail {
   class BindingPoints
@@ -39,3 +40,5 @@ namespace fastuidraw { namespace gl { namespace detail {
     int m_color_interlock_image_buffer_binding;
   };
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/binding_points.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/binding_points.hpp
@@ -32,7 +32,6 @@ namespace fastuidraw { namespace gl { namespace detail {
     int m_image_atlas_color_tiles_linear_binding;
     int m_image_atlas_index_tiles_binding;
     int m_glyph_atlas_store_binding;
-    int m_glyph_atlas_store_binding_fp16;
     int m_data_store_buffer_binding;
     int m_context_texture_binding;
     int m_coverage_buffer_texture_binding;

--- a/src/fastuidraw/internal/private/gl_backend/bindless.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/bindless.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_BINDLESS_HPP
+#define FASTUIDRAW_BINDLESS_HPP
 
 #include <fastuidraw/gl_backend/ngl_header.hpp>
 
@@ -60,3 +61,5 @@ bindless(void);
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/buffer_object_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/buffer_object_gl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_BUFFER_OBJECT_GL_HPP
+#define FASTUIDRAW_BUFFER_OBJECT_GL_HPP
 
 #include <fastuidraw/gl_backend/ngl_header.hpp>
 #include <fastuidraw/gl_backend/gl_get.hpp>
@@ -216,3 +217,5 @@ private:
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/colorstop_atlas_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/colorstop_atlas_gl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_COLORSTOP_ATLAS_GL_HPP
+#define FASTUIDRAW_COLORSTOP_ATLAS_GL_HPP
 
 #include <fastuidraw/colorstop_atlas.hpp>
 #include <fastuidraw/gl_backend/gl_program.hpp>
@@ -75,3 +76,5 @@ namespace detail
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/glyph_atlas_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/glyph_atlas_gl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_GLYPH_ATLAS_GL_HPP
+#define FASTUIDRAW_GLYPH_ATLAS_GL_HPP
 
 #include <fastuidraw/text/glyph_atlas.hpp>
 #include <fastuidraw/glsl/painter_shader_registrar_glsl.hpp>
@@ -92,3 +93,5 @@ namespace detail
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/glyph_atlas_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/glyph_atlas_gl.hpp
@@ -45,25 +45,6 @@ namespace detail
   {
   public:
     /*!
-     * Format enumeration to specify format to
-     * view the data backing as
-     */
-    enum backing_fmt_t
-      {
-        /*!
-         * Specifies to view the data as an array
-         * of uint32_t values (i.e. GL_R32UI).
-         */
-        backing_uint32_fmt,
-
-        /*!
-         * Specifes to view the data as an array
-         * of fp16-x2 values (i.e. GL_RG16F).
-         */
-        backing_fp16x2_fmt,
-      };
-
-    /*!
      * Ctor.
      * \param P parameters for constrution
      */
@@ -88,7 +69,7 @@ namespace detail
      * If backed by a buffer returns the name of a GL buffer object.
      */
     GLuint
-    data_backing(enum backing_fmt_t fmt) const;
+    data_backing(void) const;
 
     /*!
      * Returns the binding point to which to bind the objected returned

--- a/src/fastuidraw/internal/private/gl_backend/image_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/image_gl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_IMAGE_GL_HPP
+#define FASTUIDRAW_IMAGE_GL_HPP
 
 #include <fastuidraw/image.hpp>
 #include <fastuidraw/gl_backend/gl_header.hpp>
@@ -88,3 +89,5 @@ namespace detail
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/opengl_trait.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/opengl_trait.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_OPENGL_TRAIT_HPP
+#define FASTUIDRAW_OPENGL_TRAIT_HPP
 
 #include <fastuidraw/util/vecN.hpp>
 #include <fastuidraw/gl_backend/ngl_header.hpp>
@@ -315,3 +316,5 @@ VertexAttribIPointer(GLint index, const opengl_trait_value &v)
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.cpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.cpp
@@ -851,7 +851,6 @@ PainterBackendGL(const fastuidraw::gl::PainterEngineGL *f):
   m_binding_points.m_image_atlas_color_tiles_linear_binding = m_reg_gl->uber_shader_builder_params().image_atlas_color_tiles_linear_binding();
   m_binding_points.m_image_atlas_index_tiles_binding = m_reg_gl->uber_shader_builder_params().image_atlas_index_tiles_binding();
   m_binding_points.m_glyph_atlas_store_binding = m_reg_gl->uber_shader_builder_params().glyph_atlas_store_binding();
-  m_binding_points.m_glyph_atlas_store_binding_fp16 = m_reg_gl->uber_shader_builder_params().glyph_atlas_store_binding_fp16x2();
   m_binding_points.m_data_store_buffer_binding = m_reg_gl->uber_shader_builder_params().data_store_buffer_binding();
   m_binding_points.m_color_interlock_image_buffer_binding = m_reg_gl->uber_shader_builder_params().color_interlock_image_buffer_binding();
   m_binding_points.m_context_texture_binding = m_reg_gl->uber_shader_builder_params().context_texture_binding();
@@ -1079,11 +1078,7 @@ set_gl_state(RenderTargetState prev_state,
         {
           fastuidraw_glActiveTexture(GL_TEXTURE0 + m_binding_points.m_glyph_atlas_store_binding);
           fastuidraw_glBindSampler(m_binding_points.m_glyph_atlas_store_binding, 0);
-          fastuidraw_glBindTexture(m_glyph_atlas->data_binding_point(), m_glyph_atlas->data_backing(GlyphAtlasGL::backing_uint32_fmt));
-
-          fastuidraw_glActiveTexture(GL_TEXTURE0 + m_binding_points.m_glyph_atlas_store_binding_fp16);
-          fastuidraw_glBindSampler(m_binding_points.m_glyph_atlas_store_binding_fp16, 0);
-          fastuidraw_glBindTexture(m_glyph_atlas->data_binding_point(), m_glyph_atlas->data_backing(GlyphAtlasGL::backing_fp16x2_fmt));
+          fastuidraw_glBindTexture(m_glyph_atlas->data_binding_point(), m_glyph_atlas->data_backing());
         }
 
       fastuidraw_glActiveTexture(GL_TEXTURE0 + m_binding_points.m_colorstop_atlas_binding);
@@ -1139,7 +1134,7 @@ set_gl_state(RenderTargetState prev_state,
         {
           fastuidraw_glBindBufferBase(GL_SHADER_STORAGE_BUFFER,
                                       m_binding_points.m_glyph_atlas_store_binding,
-                                      m_glyph_atlas->data_backing(GlyphAtlasGL::backing_uint32_fmt));
+                                      m_glyph_atlas->data_backing());
         }
     }
 

--- a/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BACKEND_GL_HPP
+#define FASTUIDRAW_PAINTER_BACKEND_GL_HPP
 
 #include <fastuidraw/painter/backend/painter_backend.hpp>
 #include <fastuidraw/glsl/painter_shader_registrar_glsl.hpp>
@@ -141,3 +142,5 @@ namespace fastuidraw
     } //namespace detail
   } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/painter_backend_gl_config.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_backend_gl_config.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_BACKEND_GL_CONFIG_HPP
+#define FASTUIDRAW_PAINTER_BACKEND_GL_CONFIG_HPP
 
 #include <fastuidraw/gl_backend/ngl_header.hpp>
 #include <fastuidraw/gl_backend/gl_program.hpp>
@@ -58,3 +59,5 @@ compute_clipping_type(enum glsl::PainterShaderRegistrarGLSL::fbf_blending_type_t
                       bool allow_gl_clip_distance = true);
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/painter_shader_registrar_gl.cpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_shader_registrar_gl.cpp
@@ -361,6 +361,15 @@ configure_source_front_matter(void)
                                      ShaderSource::from_string);
     }
 
+  if (m_params.use_glsl_unpack_fp16())
+    {
+      m_front_matter_frag.add_macro("FASTUIDRAW_GL_HAS_UNPACKFP16");
+      m_front_matter_vert.add_macro("FASTUIDRAW_GL_HAS_UNPACKFP16");
+    }
+
+  m_front_matter_frag.add_source("fastuidraw_unpackHalf2x16.glsl.resource_string", ShaderSource::from_resource);
+  m_front_matter_vert.add_source("fastuidraw_unpackHalf2x16.glsl.resource_string", ShaderSource::from_resource);
+
   std::string glsl_version;
   #ifdef FASTUIDRAW_GL_USE_GLES
     {
@@ -449,11 +458,15 @@ configure_source_front_matter(void)
           glsl_version = "330";
 
           /* We need this extension for unpackHalf2x16() */
-          m_front_matter_vert.specify_extension("GL_ARB_shading_language_packing",
-                                                ShaderSource::require_extension);
-          m_front_matter_frag.specify_extension("GL_ARB_shading_language_packing",
-                                                ShaderSource::require_extension);
-          if (m_uber_shader_builder_params.assign_layout_to_varyings())
+	  if (m_params.use_glsl_unpack_fp16())
+	    {
+	      m_front_matter_vert.specify_extension("GL_ARB_shading_language_packing",
+						    ShaderSource::require_extension);
+	      m_front_matter_frag.specify_extension("GL_ARB_shading_language_packing",
+						    ShaderSource::require_extension);
+	    }
+
+	  if (m_uber_shader_builder_params.assign_layout_to_varyings())
             {
               m_front_matter_vert.specify_extension("GL_ARB_separate_shader_objects",
                                                     ShaderSource::require_extension);

--- a/src/fastuidraw/internal/private/gl_backend/painter_shader_registrar_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_shader_registrar_gl.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SHADER_REGISTRAR_GL_HPP
+#define FASTUIDRAW_PAINTER_SHADER_REGISTRAR_GL_HPP
 
 #include <vector>
 #include <fastuidraw/glsl/painter_shader_registrar_glsl.hpp>
@@ -228,3 +229,5 @@ private:
 };
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/painter_surface_gl_private.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_surface_gl_private.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_SURFACE_GL_PRIVATE_HPP
+#define FASTUIDRAW_PAINTER_SURFACE_GL_PRIVATE_HPP
 
 #include <fastuidraw/gl_backend/ngl_header.hpp>
 #include <fastuidraw/gl_backend/painter_engine_gl.hpp>
@@ -82,3 +83,5 @@ private:
 };
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/painter_vao_pool.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_vao_pool.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_VAO_POOL_HPP
+#define FASTUIDRAW_PAINTER_VAO_POOL_HPP
 
 #include <vector>
 #include <fastuidraw/glsl/painter_shader_registrar_glsl.hpp>
@@ -131,3 +132,5 @@ private:
 };
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/scratch_renderer.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/scratch_renderer.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_SCRATCH_RENDERER_HPP
+#define FASTUIDRAW_SCRATCH_RENDERER_HPP
 
 #include <list>
 #include <vector>
@@ -61,3 +62,5 @@ private:
 };
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/tex_buffer.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/tex_buffer.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_TEX_BUFFER_HPP
+#define FASTUIDRAW_TEX_BUFFER_HPP
 
 #include <fastuidraw/gl_backend/ngl_header.hpp>
 #include <fastuidraw/gl_backend/gl_context_properties.hpp>
@@ -48,3 +49,5 @@ tex_buffer(enum tex_buffer_support_t md, GLenum target, GLenum format, GLuint bo
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/texture_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/texture_gl.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_TEXTURE_GL_HPP
+#define FASTUIDRAW_TEXTURE_GL_HPP
 
 #include <list>
 #include <vector>
@@ -765,3 +766,5 @@ clear_texture_2d(GLuint texture, GLint level, GLenum internal_format,
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/gl_backend/texture_view.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/texture_view.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_TEXTURE_VIEW_HPP
+#define FASTUIDRAW_TEXTURE_VIEW_HPP
 
 #include <fastuidraw/gl_backend/ngl_header.hpp>
 
@@ -43,3 +44,5 @@ texture_view(enum texture_view_support_t md,
 } //namespace detail
 } //namespace gl
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/glsl/backend_shaders.hpp
+++ b/src/fastuidraw/internal/private/glsl/backend_shaders.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_BACKEND_SHADERS_HPP
+#define FASTUIDRAW_BACKEND_SHADERS_HPP
 
 #include <fastuidraw/glsl/painter_item_shader_glsl.hpp>
 #include <fastuidraw/glsl/painter_blend_shader_glsl.hpp>
@@ -176,3 +177,5 @@ private:
 };
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/glsl/dependency_list.hpp
+++ b/src/fastuidraw/internal/private/glsl/dependency_list.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_DEPENDENCY_LIST_HPP
+#define FASTUIDRAW_DEPENDENCY_LIST_HPP
 
 #include <string>
 #include <algorithm>
@@ -400,3 +401,5 @@ compute_varyings(const varying_list &combine_with) const
 }
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/glsl/uber_shader_builder.hpp
+++ b/src/fastuidraw/internal/private/glsl/uber_shader_builder.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_UBER_SHADER_BUILDER_HPP
+#define FASTUIDRAW_UBER_SHADER_BUILDER_HPP
 
 #include <vector>
 #include <string>
@@ -213,3 +214,5 @@ stream_uber_blend_shader(bool use_switch, ShaderSource &frag,
 
 
 }}}
+
+#endif

--- a/src/fastuidraw/internal/private/int_path.hpp
+++ b/src/fastuidraw/internal/private/int_path.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_INT_PATH_HPP
+#define FASTUIDRAW_INT_PATH_HPP
 
 #include <vector>
 
@@ -458,3 +459,5 @@ namespace fastuidraw
 
   } //namespace fastuidraw
 } //namespace detail
+
+#endif

--- a/src/fastuidraw/internal/private/interval_allocator.hpp
+++ b/src/fastuidraw/internal/private/interval_allocator.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_INTERVAL_ALLOCATOR_HPP
+#define FASTUIDRAW_INTERVAL_ALLOCATOR_HPP
 
 #include <map>
 #include <set>
@@ -176,3 +177,5 @@ namespace fastuidraw
   };
 
 }
+
+#endif

--- a/src/fastuidraw/internal/private/pack_texels.hpp
+++ b/src/fastuidraw/internal/private/pack_texels.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PACK_TEXELS_HPP
+#define FASTUIDRAW_PACK_TEXELS_HPP
 
 #include <vector>
 
@@ -38,3 +39,5 @@ namespace fastuidraw
                 std::vector<uint32_t> *out_packed_texels);
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/painter_backend/painter_packed_value_pool_private.hpp
+++ b/src/fastuidraw/internal/private/painter_backend/painter_packed_value_pool_private.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_PACKED_VALUE_POOL_PRIVATE_HPP
+#define FASTUIDRAW_PAINTER_PACKED_VALUE_POOL_PRIVATE_HPP
 
 #include <vector>
 #include <fastuidraw/util/reference_counted.hpp>
@@ -474,3 +475,5 @@ namespace fastuidraw
     };
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/painter_backend/painter_packer.hpp
+++ b/src/fastuidraw/internal/private/painter_backend/painter_packer.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_PACKER_HPP
+#define FASTUIDRAW_PAINTER_PACKER_HPP
 
 #include <vector>
 #include <list>
@@ -466,3 +467,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/src/fastuidraw/internal/private/painter_backend/painter_packer_data.hpp
+++ b/src/fastuidraw/internal/private/painter_backend/painter_packer_data.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_PACKER_DATA_HPP
+#define FASTUIDRAW_PAINTER_PACKER_DATA_HPP
 
 #include <fastuidraw/painter/shader_data/painter_data.hpp>
 #include <fastuidraw/painter/backend/painter_brush_adjust.hpp>
@@ -71,3 +72,5 @@ namespace fastuidraw
 /*! @} */
 
 }
+
+#endif

--- a/src/fastuidraw/internal/private/painter_stroking_data_selector_common.hpp
+++ b/src/fastuidraw/internal/private/painter_stroking_data_selector_common.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_PAINTER_STROKING_DATA_SELECTOR_COMMON_HPP
+#define FASTUIDRAW_PAINTER_STROKING_DATA_SELECTOR_COMMON_HPP
 
 #include <cmath>
 #include <fastuidraw/painter/shader/painter_stroke_shader.hpp>
@@ -115,3 +116,5 @@ namespace fastuidraw
     };
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/path_util_private.hpp
+++ b/src/fastuidraw/internal/private/path_util_private.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_PATH_UTIL_PRIVATE_HPP
+#define FASTUIDRAW_PATH_UTIL_PRIVATE_HPP
 
 #include <fastuidraw/util/math.hpp>
 #include <fastuidraw/tessellated_path.hpp>
@@ -93,3 +94,5 @@ namespace fastuidraw
     }
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/point_attribute_data_merger.hpp
+++ b/src/fastuidraw/internal/private/point_attribute_data_merger.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_POINT_ATTRIBUTE_DATA_MERGER_HPP
+#define FASTUIDRAW_POINT_ATTRIBUTE_DATA_MERGER_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/painter/attribute_data/painter_attribute_data.hpp>
@@ -200,3 +201,5 @@ fill_data_helper_idx(unsigned int incr_idx,
 
 
 }}
+
+#endif

--- a/src/fastuidraw/internal/private/rect_atlas.hpp
+++ b/src/fastuidraw/internal/private/rect_atlas.hpp
@@ -17,7 +17,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_RECT_ATLAS_HPP
+#define FASTUIDRAW_RECT_ATLAS_HPP
 
 #include <list>
 #include <map>
@@ -348,3 +349,5 @@ private:
 } //namespace detail
 
 } //namespace fastuidraw
+
+#endif

--- a/src/fastuidraw/internal/private/simple_pool.hpp
+++ b/src/fastuidraw/internal/private/simple_pool.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_SIMPLE_POOL_HPP
+#define FASTUIDRAW_SIMPLE_POOL_HPP
 
 #include <fastuidraw/util/util.hpp>
 #include <fastuidraw/util/vecN.hpp>
@@ -137,3 +138,5 @@ private:
 };
 
 }}
+
+#endif

--- a/src/fastuidraw/internal/private/util_private.hpp
+++ b/src/fastuidraw/internal/private/util_private.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_UTIL_PRIVATE_HPP
+#define FASTUIDRAW_UTIL_PRIVATE_HPP
 
 #include <iostream>
 #include <vector>
@@ -194,3 +195,5 @@ namespace fastuidraw
     std::cerr << "Warning: [" << __FILE__ << ", "  \
               << __LINE__ << "] " << #X << "\n";    \
   } while(0)
+
+#endif

--- a/src/fastuidraw/internal/private/util_private_math.hpp
+++ b/src/fastuidraw/internal/private/util_private_math.hpp
@@ -16,7 +16,8 @@
  *
  */
 
-#pragma once
+#ifndef FASTUIDRAW_UTIL_PRIVATE_MATH_HPP
+#define FASTUIDRAW_UTIL_PRIVATE_MATH_HPP
 
 #include <fastuidraw/util/matrix.hpp>
 #include <fastuidraw/util/math.hpp>
@@ -29,3 +30,5 @@ namespace fastuidraw
     compute_singular_values(const float2x2 &matrix);
   }
 }
+
+#endif

--- a/src/fastuidraw/internal/private/util_private_ostream.hpp
+++ b/src/fastuidraw/internal/private/util_private_ostream.hpp
@@ -17,7 +17,8 @@
  */
 
 
-#pragma once
+#ifndef FASTUIDRAW_UTIL_PRIVATE_OSTREAM_HPP
+#define FASTUIDRAW_UTIL_PRIVATE_OSTREAM_HPP
 
 #include <vector>
 #include <iostream>
@@ -225,3 +226,5 @@ operator<<(fastuidraw::glsl::ShaderSource &src, const T &obj)
   src.add_source(str.str().c_str(), fastuidraw::glsl::ShaderSource::from_string);
   return src;
 }
+
+#endif


### PR DESCRIPTION
This fixes a terrible typo permuting GLES and GL in the code fix.