### PR TITLE
PR to add more options for streaming index, attribute and store data to GPU

### DIFF
--- a/demos/common/sdl_painter_demo.cpp
+++ b/demos/common/sdl_painter_demo.cpp
@@ -139,6 +139,29 @@ namespace
   }
 
   std::ostream&
+  operator<<(std::ostream &str,
+             enum_wrapper<enum fastuidraw::gl::PainterEngineGL::buffer_streaming_type_t> v)
+  {
+    switch (v.m_v)
+      {
+      case fastuidraw::gl::PainterEngineGL::buffer_streaming_use_mapping:
+        str << "buffer_streaming_use_mapping";
+        break;
+
+      case fastuidraw::gl::PainterEngineGL::buffer_streaming_orphaning:
+        str << "buffer_streaming_orphaning";
+        break;
+
+      case fastuidraw::gl::PainterEngineGL::buffer_streaming_buffer_subdata:
+        str << "buffer_streaming_buffer_subdata";
+        break;
+      default:
+        str << "invalid value";
+      }
+    return str;
+  }
+
+  std::ostream&
   operator<<(std::ostream &ostr, const fastuidraw::PainterShader::Tag &tag)
   {
     ostr << "(ID=" << tag.m_ID << ", group=" << tag.m_group << ")";
@@ -373,6 +396,20 @@ sdl_painter_demo(const std::string &about_text,
                                         "bindless texturing, the the textures of the surfaces "
                                         "rendered to will be textured with bindless texturing",
                                         *this),
+  m_buffer_streaming_type(m_painter_params.buffer_streaming_type(),
+			  enumerated_string_type<enum fastuidraw::gl::PainterEngineGL::buffer_streaming_type_t>()
+			  .add_entry("buffer_streaming_use_mapping",
+				     fastuidraw::gl::PainterEngineGL::buffer_streaming_use_mapping,
+				     "Use glMapBufferRange and glFlushMappedBufferRange recycling BO's across frames")
+			  .add_entry("buffer_streaming_orphaning",
+				     fastuidraw::gl::PainterEngineGL::buffer_streaming_orphaning,
+				     "Call glBufferData each frame to orphan the previous buffer contents but reuse BO names across frames")
+			  .add_entry("buffer_streaming_buffer_subdata",
+				     fastuidraw::gl::PainterEngineGL::buffer_streaming_buffer_subdata,
+				     "Call glBufferSubData thus reusing BO's across frames"),
+			  "painter_buffer_streaming",
+			  "",
+			  *this),
   m_painter_options_affected_by_context("PainterBackendGL Options that can be overridden "
                                         "by version and extension supported by GL/GLES context",
                                         *this),
@@ -576,6 +613,7 @@ init_gl(int w, int h)
   APPLY_PARAM(number_pools, m_painter_number_pools);
   APPLY_PARAM(break_on_shader_change, m_painter_break_on_shader_change);
   APPLY_PARAM(clipping_type, m_use_hw_clip_planes);
+  APPLY_PARAM(buffer_streaming_type, m_buffer_streaming_type);
   APPLY_PARAM(vert_shader_use_switch, m_uber_vert_use_switch);
   APPLY_PARAM(frag_shader_use_switch, m_uber_frag_use_switch);
   APPLY_PARAM(blend_shader_use_switch, m_uber_blend_use_switch);
@@ -766,6 +804,7 @@ init_gl(int w, int h)
       LAZY_PARAM(indices_per_buffer, m_painter_indices_per_buffer);
       LAZY_PARAM(data_blocks_per_store_buffer, m_painter_data_blocks_per_buffer);
       LAZY_PARAM(number_pools, m_painter_number_pools);
+      LAZY_PARAM_ENUM(buffer_streaming_type, m_buffer_streaming_type);
       LAZY_PARAM_ENUM(break_on_shader_change, m_painter_break_on_shader_change);
       LAZY_PARAM_ENUM(clipping_type, m_use_hw_clip_planes);
       LAZY_PARAM_ENUM(vert_shader_use_switch, m_uber_vert_use_switch);

--- a/demos/common/sdl_painter_demo.hpp
+++ b/demos/common/sdl_painter_demo.hpp
@@ -154,6 +154,7 @@ private:
   command_line_argument_value<bool> m_uber_blend_use_switch;
   command_line_argument_value<bool> m_separate_program_for_discard;
   command_line_argument_value<bool> m_allow_bindless_texture_from_surface;
+  enumerated_command_line_argument_value<enum fastuidraw::gl::PainterEngineGL::buffer_streaming_type_t> m_buffer_streaming_type;
 
   /* Painter params that can be overridden by properties of GL context */
   command_separator m_painter_options_affected_by_context;

--- a/inc/fastuidraw/gl_backend/painter_engine_gl.hpp
+++ b/inc/fastuidraw/gl_backend/painter_engine_gl.hpp
@@ -87,6 +87,32 @@ namespace fastuidraw
         };
 
       /*!
+       * !\brief
+       * Specifies how to stream buffers into GL
+       */
+      enum buffer_streaming_type_t
+	{
+	 /*!
+	  * Reuse GL buffer objects and stream the data
+	  * via glMapBufferRange
+	  */
+	 buffer_streaming_use_mapping,
+
+	 /*!
+	  * Reuse the same GL buffer NAMES, but use
+	  * glBufferData() to orphan the GL buffer
+	  * objects to replace the data.
+	  */
+	 buffer_streaming_orphaning,
+
+	 /*!
+	  * Reuse the GL buffer objects and stream the
+	  * data via glBufferSubData
+	  */
+	 buffer_streaming_buffer_subdata,
+	};
+
+      /*!
        * \brief
        * Class to hold the construction parameters for creating
        * the GL-backend \ref ImageAtlas for a \ref PainterEngineGL.
@@ -839,6 +865,33 @@ namespace fastuidraw
          */
         ConfigurationGL&
         allow_bindless_texture_from_surface(bool);
+
+	/*!
+	 * Specifies how attribute, index and data-store
+	 * is streamed to the GL buffer objects used in
+	 * drawing. Default value is \ref buffer_streaming_use_mapping
+	 */
+	enum buffer_streaming_type_t
+	buffer_streaming_type(void) const;
+
+	/*!
+	 * Set the value returned by \ref buffer_streaming_type(void) const
+	 */
+	ConfigurationGL&
+	buffer_streaming_type(enum buffer_streaming_type_t);
+
+	/*!
+	 * If true, for each PainterBackend made from the PainterEngineGL,
+	 * the same GL context will access it. Default value is true.
+	 */
+	bool
+	assume_single_gl_context(void) const;
+
+	/*!
+	 * Set the value returned by \ref assume_single_gl_context(void) const
+	 */
+	ConfigurationGL&
+	assume_single_gl_context(bool);
 
         /*!
          * If a non-empty string, gives the GLSL version to be used

--- a/src/fastuidraw/gl_backend/painter_engine_gl.cpp
+++ b/src/fastuidraw/gl_backend/painter_engine_gl.cpp
@@ -116,6 +116,8 @@ namespace
       m_preferred_blend_type(fastuidraw::PainterBlendShader::dual_src),
       m_fbf_blending_type(fastuidraw::glsl::PainterShaderRegistrarGLSL::fbf_blending_not_supported),
       m_allow_bindless_texture_from_surface(true),
+      m_buffer_streaming_type(fastuidraw::gl::PainterEngineGL::buffer_streaming_use_mapping),
+      m_assume_single_gl_context(true),
       m_support_dual_src_blend_shaders(true),
       m_use_uber_item_shader(true),
       m_use_glsl_unpack_fp16(true)
@@ -139,6 +141,8 @@ namespace
     enum fastuidraw::PainterBlendShader::shader_type m_preferred_blend_type;
     enum fastuidraw::glsl::PainterShaderRegistrarGLSL::fbf_blending_type_t m_fbf_blending_type;
     bool m_allow_bindless_texture_from_surface;
+    enum fastuidraw::gl::PainterEngineGL::buffer_streaming_type_t m_buffer_streaming_type;
+    bool m_assume_single_gl_context;
     bool m_support_dual_src_blend_shaders;
     bool m_use_uber_item_shader;
     bool m_use_glsl_unpack_fp16;
@@ -1106,6 +1110,10 @@ setget_implement(fastuidraw::gl::PainterEngineGL::ConfigurationGL, Configuration
                  bool, use_uber_item_shader)
 setget_implement(fastuidraw::gl::PainterEngineGL::ConfigurationGL, ConfigurationGLPrivate,
                  bool, use_glsl_unpack_fp16)
+setget_implement(fastuidraw::gl::PainterEngineGL::ConfigurationGL, ConfigurationGLPrivate,
+		 enum fastuidraw::gl::PainterEngineGL::buffer_streaming_type_t, buffer_streaming_type)
+setget_implement(fastuidraw::gl::PainterEngineGL::ConfigurationGL, ConfigurationGLPrivate,
+                 bool, assume_single_gl_context)
 get_implement(fastuidraw::gl::PainterEngineGL::ConfigurationGL, ConfigurationGLPrivate,
               const fastuidraw::gl::PainterEngineGL::ImageAtlasParams&, image_atlas_params)
 get_implement(fastuidraw::gl::PainterEngineGL::ConfigurationGL, ConfigurationGLPrivate,

--- a/src/fastuidraw/gl_backend/painter_engine_gl.cpp
+++ b/src/fastuidraw/gl_backend/painter_engine_gl.cpp
@@ -793,6 +793,13 @@ configure_from_context(bool choose_optimal_rendering_quality,
    */
   d->m_number_pools = 3;
 
+  /* TODO: query the GPU "somehow" to see if it has
+   * dedicated memory or shared memory. The latter
+   * will prefer m_buffer_streaming_type to be
+   * buffer_streaming_use_mapping where as the former
+   * will likely prefer buffer_streaming_orphaning
+   */
+  
   /* For now, choosing optimal rendering quality does not
    * have impact on options.
    */

--- a/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.cpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.cpp
@@ -210,10 +210,7 @@ public:
               PainterBackendGL *pr);
 
   virtual
-  ~DrawCommand()
-  {
-    m_pool->release_vao(m_vao);
-  }
+  ~DrawCommand();
 
   virtual
   bool
@@ -304,7 +301,7 @@ draw(fastuidraw::gl::detail::PainterBackendGL *pr,
        */
       fastuidraw_glBindVertexArray(0);
       flags |= m_action->execute(pr);
-      fastuidraw_glBindVertexArray(vao.m_vao);
+      fastuidraw_glBindVertexArray(vao.vao());
     }
 
   if (m_set_blend)
@@ -373,42 +370,17 @@ DrawCommand(const reference_counted_ptr<painter_vao_pool> &hnd,
   m_attributes_written(0),
   m_indices_written(0)
 {
-  /* map the buffers and set to the c_array<> fields of
-   * fastuidraw::PainterDraw to the mapping location.
-   */
-  void *attr_bo, *index_bo, *data_bo, *header_bo;
-  uint32_t flags;
+  FASTUIDRAWunused(params);
+  m_attributes = m_vao.attributes();
+  m_indices = m_vao.indices();
+  m_store = m_vao.data();
+  m_header_attributes = m_vao.header_attributes();
+}
 
-  flags = GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_FLUSH_EXPLICIT_BIT;
-
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, m_vao.m_attribute_bo);
-  attr_bo = fastuidraw_glMapBufferRange(GL_ARRAY_BUFFER, 0, hnd->attribute_buffer_size(), flags);
-  FASTUIDRAWassert(attr_bo != nullptr);
-
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, m_vao.m_header_bo);
-  header_bo = fastuidraw_glMapBufferRange(GL_ARRAY_BUFFER, 0, hnd->header_buffer_size(), flags);
-  FASTUIDRAWassert(header_bo != nullptr);
-
-  fastuidraw_glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_vao.m_index_bo);
-  index_bo = fastuidraw_glMapBufferRange(GL_ELEMENT_ARRAY_BUFFER, 0, hnd->index_buffer_size(), flags);
-  FASTUIDRAWassert(index_bo != nullptr);
-
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, m_vao.m_data_bo);
-  data_bo = fastuidraw_glMapBufferRange(GL_ARRAY_BUFFER, 0, hnd->data_buffer_size(), flags);
-  FASTUIDRAWassert(data_bo != nullptr);
-
-  m_attributes = c_array<PainterAttribute>(static_cast<PainterAttribute*>(attr_bo),
-                                           params.attributes_per_buffer());
-  m_indices = c_array<PainterIndex>(static_cast<PainterIndex*>(index_bo),
-                                    params.indices_per_buffer());
-  m_store = c_array<uvec4>(static_cast<uvec4*>(data_bo),
-                                            hnd->data_buffer_size() / sizeof(uvec4));
-
-  m_header_attributes = c_array<uint32_t>(static_cast<uint32_t*>(header_bo),
-                                          params.attributes_per_buffer());
-
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, 0);
-  fastuidraw_glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+fastuidraw::gl::detail::PainterBackendGL::DrawCommand::
+~DrawCommand()
+{
+  m_pool->release_vao(m_vao);
 }
 
 bool
@@ -514,25 +486,25 @@ void
 fastuidraw::gl::detail::PainterBackendGL::DrawCommand::
 draw(void) const
 {
-  fastuidraw_glBindVertexArray(m_vao.m_vao);
-  switch(m_vao.m_data_store_backing)
+  fastuidraw_glBindVertexArray(m_vao.vao());
+  switch(m_vao.data_store_backing())
     {
     case PainterEngineGL::data_store_tbo:
       {
-        fastuidraw_glActiveTexture(GL_TEXTURE0 + m_vao.m_data_store_binding_point);
-        fastuidraw_glBindTexture(GL_TEXTURE_BUFFER, m_vao.m_data_tbo);
+        fastuidraw_glActiveTexture(GL_TEXTURE0 + m_vao.data_store_binding_point());
+        fastuidraw_glBindTexture(GL_TEXTURE_BUFFER, m_vao.data_tbo());
       }
       break;
 
     case PainterEngineGL::data_store_ubo:
       {
-        fastuidraw_glBindBufferBase(GL_UNIFORM_BUFFER, m_vao.m_data_store_binding_point, m_vao.m_data_bo);
+        fastuidraw_glBindBufferBase(GL_UNIFORM_BUFFER, m_vao.data_store_binding_point(), m_vao.data_bo());
       }
       break;
 
     case PainterEngineGL::data_store_ssbo:
       {
-        fastuidraw_glBindBufferBase(GL_SHADER_STORAGE_BUFFER, m_vao.m_data_store_binding_point, m_vao.m_data_bo);
+        fastuidraw_glBindBufferBase(GL_SHADER_STORAGE_BUFFER, m_vao.data_store_binding_point(), m_vao.data_bo());
       }
       break;
 
@@ -557,21 +529,10 @@ unmap_implement(unsigned int attributes_written,
   add_entry(indices_written);
   FASTUIDRAWassert(m_indices_written == indices_written);
 
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, m_vao.m_attribute_bo);
-  fastuidraw_glFlushMappedBufferRange(GL_ARRAY_BUFFER, 0, attributes_written * sizeof(PainterAttribute));
-  fastuidraw_glUnmapBuffer(GL_ARRAY_BUFFER);
-
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, m_vao.m_header_bo);
-  fastuidraw_glFlushMappedBufferRange(GL_ARRAY_BUFFER, 0, attributes_written * sizeof(uint32_t));
-  fastuidraw_glUnmapBuffer(GL_ARRAY_BUFFER);
-
-  fastuidraw_glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_vao.m_index_bo);
-  fastuidraw_glFlushMappedBufferRange(GL_ELEMENT_ARRAY_BUFFER, 0, indices_written * sizeof(PainterIndex));
-  fastuidraw_glUnmapBuffer(GL_ELEMENT_ARRAY_BUFFER);
-
-  fastuidraw_glBindBuffer(GL_ARRAY_BUFFER, m_vao.m_data_bo);
-  fastuidraw_glFlushMappedBufferRange(GL_ARRAY_BUFFER, 0, data_store_written * sizeof(uvec4));
-  fastuidraw_glUnmapBuffer(GL_ARRAY_BUFFER);
+  m_pool->unmap_vao_buffers(attributes_written,
+			    indices_written,
+			    data_store_written,
+			    m_vao);
 }
 
 void
@@ -708,27 +669,27 @@ restore_gl_state(const fastuidraw::gl::detail::painter_vao &vao,
   /* If necessary, restore the UBO or TBO assoicated to the data
    * store binding point.
    */
-  switch(vao.m_data_store_backing)
+  switch(vao.data_store_backing())
     {
     case PainterEngineGL::data_store_tbo:
       if (flags & gpu_dirty_state::textures)
         {
-          fastuidraw_glActiveTexture(GL_TEXTURE0 + vao.m_data_store_binding_point);
-          fastuidraw_glBindTexture(GL_TEXTURE_BUFFER, vao.m_data_tbo);
+          fastuidraw_glActiveTexture(GL_TEXTURE0 + vao.data_store_binding_point());
+          fastuidraw_glBindTexture(GL_TEXTURE_BUFFER, vao.data_tbo());
         }
       break;
 
     case PainterEngineGL::data_store_ubo:
       if (flags & gpu_dirty_state::constant_buffers)
         {
-          fastuidraw_glBindBufferBase(GL_UNIFORM_BUFFER, vao.m_data_store_binding_point, vao.m_data_bo);
+          fastuidraw_glBindBufferBase(GL_UNIFORM_BUFFER, vao.data_store_binding_point(), vao.data_bo());
         }
       break;
 
     case PainterEngineGL::data_store_ssbo:
       if (flags & gpu_dirty_state::storage_buffers)
         {
-          fastuidraw_glBindBufferBase(GL_SHADER_STORAGE_BUFFER, vao.m_data_store_binding_point, vao.m_data_bo);
+          fastuidraw_glBindBufferBase(GL_SHADER_STORAGE_BUFFER, vao.data_store_binding_point(), vao.data_bo());
         }
       break;
 

--- a/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_backend_gl.hpp
@@ -126,6 +126,7 @@ namespace fastuidraw
         reference_counted_ptr<GlyphAtlasGL> m_glyph_atlas;
         reference_counted_ptr<ImageAtlasGL> m_image_atlas;
         reference_counted_ptr<ColorStopAtlasGL> m_colorstop_atlas;
+	std::vector<uint32_t> m_uniform_values;
 
         GLuint m_nearest_filter_sampler;
         reference_counted_ptr<painter_vao_pool> m_pool;

--- a/src/fastuidraw/internal/private/gl_backend/painter_vao_pool.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_vao_pool.hpp
@@ -105,6 +105,12 @@ public:
   void
   release_vao(painter_vao &V);
 
+  static
+  void
+  prepare_index_vertex_sources(GLuint attribute_bo,
+			       GLuint header_attribute_bo,
+			       GLuint index_bo);
+
 private:
   GLuint
   generate_tbo(GLuint src_buffer, GLenum fmt, unsigned int unit);
@@ -125,6 +131,7 @@ private:
   enum glsl::PainterShaderRegistrarGLSL::data_store_backing_t m_data_store_backing;
   enum tex_buffer_support_t m_tex_buffer_support;
   unsigned int m_data_store_binding;
+  bool m_assume_single_gl_context;
 
   unsigned int m_current_pool;
   std::vector<std::vector<painter_vao> > m_free_vaos;

--- a/src/fastuidraw/internal/private/gl_backend/painter_vao_pool.hpp
+++ b/src/fastuidraw/internal/private/gl_backend/painter_vao_pool.hpp
@@ -32,6 +32,24 @@
 
 namespace fastuidraw { namespace gl { namespace detail {
 
+class client_buffers:public reference_counted<client_buffers>::non_concurrent
+{
+public:
+  client_buffers(uint32_t num_attributes,
+		 uint32_t num_indices,
+		 uint32_t num_data):
+    m_attributes_store(num_attributes),
+    m_header_attributes_store(num_attributes),
+    m_indices_store(num_indices),
+    m_data_store(num_data)
+  {}
+
+  std::vector<PainterAttribute> m_attributes_store;
+  std::vector<uint32_t> m_header_attributes_store;
+  std::vector<PainterIndex> m_indices_store;
+  std::vector<uvec4> m_data_store;
+};
+      
 class painter_vao
 {
 public:
@@ -43,6 +61,62 @@ public:
     m_data_bo(0),
     m_data_tbo(0)
   {}
+  
+  c_array<PainterAttribute>
+  attributes(void) const
+  {
+    return m_attributes;
+  }
+  c_array<uint32_t>
+  header_attributes(void) const
+  {
+    return m_header_attributes;
+  }
+
+  c_array<PainterIndex>
+  indices(void) const
+  {
+    return m_indices;
+  }
+
+  c_array<uvec4>
+  data(void) const
+  {
+    return m_data;
+  }
+
+  GLuint
+  vao(void) const
+  {
+    return m_vao;
+  }
+
+  enum glsl::PainterShaderRegistrarGLSL::data_store_backing_t
+  data_store_backing(void) const
+  {
+    return m_data_store_backing;
+  }
+
+  unsigned int
+  data_store_binding_point(void) const
+  {
+    return m_data_store_binding_point;
+  }
+
+  GLuint
+  data_bo(void) const
+  {
+    return m_data_bo;
+  }
+
+  GLuint
+  data_tbo(void) const
+  {
+    return m_data_tbo;
+  }
+  
+private:
+  friend class painter_vao_pool;
 
   GLuint m_vao;
   GLuint m_attribute_bo, m_header_bo, m_index_bo, m_data_bo;
@@ -50,6 +124,11 @@ public:
   enum glsl::PainterShaderRegistrarGLSL::data_store_backing_t m_data_store_backing;
   unsigned int m_data_store_binding_point;
   unsigned int m_pool;
+  reference_counted_ptr<client_buffers> m_buffers;
+  c_array<PainterAttribute> m_attributes;
+  c_array<uint32_t> m_header_attributes;
+  c_array<PainterIndex> m_indices;
+  c_array<uvec4> m_data;
 };
 
 class painter_vao_pool:public reference_counted<painter_vao_pool>::non_concurrent
@@ -62,32 +141,11 @@ public:
 
   ~painter_vao_pool();
 
-  unsigned int
-  attribute_buffer_size(void) const
-  {
-    return m_attribute_buffer_size;
-  }
-
-  unsigned int
-  header_buffer_size(void) const
-  {
-    return m_header_buffer_size;
-  }
-
-  unsigned int
-  index_buffer_size(void) const
-  {
-    return m_index_buffer_size;
-  }
-
-  unsigned int
-  data_buffer_size(void) const
-  {
-    return m_data_buffer_size;
-  }
-
   painter_vao
   request_vao(void);
+
+  void
+  release_vao(painter_vao &V);
 
   void
   next_pool(void);
@@ -102,14 +160,17 @@ public:
   GLuint
   uniform_ubo(unsigned int ubo_size, GLenum target);
 
-  void
-  release_vao(painter_vao &V);
-
   static
   void
   prepare_index_vertex_sources(GLuint attribute_bo,
 			       GLuint header_attribute_bo,
 			       GLuint index_bo);
+
+  void
+  unmap_vao_buffers(unsigned int attributes_written,
+		    unsigned int indices_written,
+		    unsigned int data_store_written,
+		    const painter_vao &vao);
 
 private:
   GLuint
@@ -124,14 +185,12 @@ private:
   void
   release_vao_resources(const painter_vao &V);
 
-  unsigned int m_attribute_buffer_size, m_header_buffer_size;
-  unsigned int m_index_buffer_size;
-  int m_blocks_per_data_buffer;
-  unsigned int m_data_buffer_size;
+  unsigned int m_num_attributes, m_num_indices, m_blocks_per_data_buffer;
   enum glsl::PainterShaderRegistrarGLSL::data_store_backing_t m_data_store_backing;
   enum tex_buffer_support_t m_tex_buffer_support;
   unsigned int m_data_store_binding;
   bool m_assume_single_gl_context;
+  enum PainterEngineGL::buffer_streaming_type_t m_buffer_streaming_type;
 
   unsigned int m_current_pool;
   std::vector<std::vector<painter_vao> > m_free_vaos;


### PR DESCRIPTION
A fair number of GPU's  with dedicated memory (see the closed issue: https://github.com/intel/fastuidraw/issues/49) do NOT operate well (because of kernel driver load) with doing glMapBufferRange()-glFlushMappedBufferRange() strategy for streaming data.

The patch series adds two additional streaming methods that should significantly help such cards jeep their CPU loads low.